### PR TITLE
feat(crossfade): update metadata to next song immediately when crossfade starts

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
@@ -1800,6 +1800,78 @@ class MusicService :
         }
     }
 
+    private suspend fun awaitPrimaryCrossfadeHandoffReady(
+        incomingPlayer: ExoPlayer,
+    ): Boolean {
+        val deadlineMs = android.os.SystemClock.elapsedRealtime() + CROSSFADE_HANDOFF_READY_TIMEOUT_MS
+        while (kotlinx.coroutines.currentCoroutineContext().isActive && android.os.SystemClock.elapsedRealtime() < deadlineMs) {
+            if (player.playbackState == Player.STATE_READY && canHandoffWithoutRebuffer(incomingPlayer)) {
+                return true
+            }
+            if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
+                return false
+            }
+            delay(25L)
+        }
+        return player.playbackState == Player.STATE_READY && canHandoffWithoutRebuffer(incomingPlayer)
+    }
+
+    private fun canHandoffWithoutRebuffer(incomingPlayer: ExoPlayer): Boolean {
+        if (player.currentMediaItem?.localConfiguration?.uri?.shouldBypassPlayerCache() == true) return true
+        if (hasBufferedForSmoothStart(player, CROSSFADE_HANDOFF_BUFFER_MS)) {
+            val bufferedPosition = player.bufferedPosition
+            val incomingPosition = incomingPlayer.currentPosition.coerceAtLeast(0L)
+            return bufferedPosition == C.TIME_UNSET ||
+                incomingPosition + CROSSFADE_HANDOFF_SEEK_GUARD_MS <= bufferedPosition
+        }
+        return false
+    }
+
+    private fun requiredCrossfadeStartBufferMs(durationMs: Long): Long =
+        (durationMs + CROSSFADE_HANDOFF_BUFFER_MS)
+            .coerceAtLeast(CROSSFADE_MIN_BUFFER_BEFORE_START_MS)
+            .coerceAtMost(CROSSFADE_MAX_BUFFER_BEFORE_START_MS)
+
+    private fun hasBufferedForSmoothStart(
+        targetPlayer: ExoPlayer,
+        minimumBufferedMs: Long,
+    ): Boolean {
+        if (minimumBufferedMs <= 0L) return true
+        if (targetPlayer.currentMediaItem?.localConfiguration?.uri?.shouldBypassPlayerCache() == true) return true
+
+        val duration = targetPlayer.duration
+        val currentPosition = targetPlayer.currentPosition.coerceAtLeast(0L)
+        val remainingDuration =
+            if (duration != C.TIME_UNSET && duration > currentPosition) {
+                duration - currentPosition
+            } else {
+                Long.MAX_VALUE
+            }
+        val requiredBufferedMs = minimumBufferedMs.coerceAtMost(remainingDuration)
+        if (requiredBufferedMs <= 0L) return true
+
+        val bufferedDuration = targetPlayer.totalBufferedDuration.coerceAtLeast(0L)
+        if (bufferedDuration >= requiredBufferedMs) return true
+
+        return duration != C.TIME_UNSET &&
+            targetPlayer.bufferedPosition >= duration - CROSSFADE_END_GUARD_MS
+    }
+
+    private fun resolveCrossfadeTargetIndex(target: CrossfadeTarget): Int {
+        if (target.index in 0 until player.mediaItemCount &&
+            player.getMediaItemAt(target.index).mediaId == target.mediaId
+        ) {
+            return target.index
+        }
+
+        for (index in 0 until player.mediaItemCount) {
+            if (player.getMediaItemAt(index).mediaId == target.mediaId) {
+                return index
+            }
+        }
+        return C.INDEX_UNSET
+    }
+
     private fun releaseSecondaryCrossfadePlayer() {
         val playerToRelease = secondaryCrossfadePlayer ?: return
         secondaryCrossfadePlayer = null

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
@@ -410,10 +410,14 @@ class MusicService :
     private var secondaryCrossfadePlayer: ExoPlayer? = null
     private var secondaryCrossfadeTarget: CrossfadeTarget? = null
     private var isCrossfading = false
+    val isCrossfadingState = MutableStateFlow(false)
     private var crossfadeHandoffInProgress = false
     private var crossfadeBaseVolume = 1f
     private var crossfadeProgress = 0f
     private var crossfadePlaybackRequested = false
+    private var previousCrossfadeMetadata: moe.koiverse.archivetune.models.MediaMetadata? = null
+    private var crossfadeRestoreMetadataOnCancel = false
+    val crossfadeIncomingPosition = MutableStateFlow(-1L)
     private var lyricsPreloadManager: LyricsPreloadManager? = null
 
     private val secondaryCrossfadeListener =
@@ -1289,7 +1293,13 @@ class MusicService :
                 DiscordPresenceManager.start(
                     context = this@MusicService,
                     token = key,
-                    songProvider = { player.currentMetadata?.let { createTransientSongFromMedia(it) } ?: currentSong.value },
+                    songProvider = {
+                        if (isCrossfading) {
+                            currentMediaMetadata.value?.let { createTransientSongFromMedia(it) } ?: currentSong.value
+                        } else {
+                            player.currentMetadata?.let { createTransientSongFromMedia(it) } ?: currentSong.value
+                        }
+                    },
                     positionProvider = { player.currentPosition },
                     isPausedProvider = { !player.isPlaying },
                     intervalProvider = { getPresenceIntervalMillis(this@MusicService) }
@@ -1626,6 +1636,7 @@ class MusicService :
         crossfadeJob =
             scope.launch {
                 isCrossfading = true
+                isCrossfadingState.value = true
                 crossfadeProgress = 0f
                 crossfadeBaseVolume = currentEffectivePlayerVolume()
                 crossfadePlaybackRequested = player.playWhenReady
@@ -1645,6 +1656,23 @@ class MusicService :
                         incomingPlayer.play()
                     }
 
+                    // Update metadata to the incoming song immediately
+                    previousCrossfadeMetadata = currentMediaMetadata.value
+                    crossfadeRestoreMetadataOnCancel = true
+                    player.getMediaItemAt(target.index).metadata?.let { incomingMediaMetadata ->
+                        currentMediaMetadata.value = incomingMediaMetadata
+                    }
+
+                    // Immediately update Discord presence to the incoming song
+                    if (DiscordPresenceManager.isRunning()) {
+                        try {
+                            DiscordPresenceManager.restart()
+                        } catch (_: Exception) {}
+                    }
+
+                    // Force notification to update with new song metadata
+                    refreshPlaybackNotification()
+
                     var elapsedMs = 0L
                     var lastTickMs = android.os.SystemClock.elapsedRealtime()
                     while (isActive && elapsedMs < durationMs) {
@@ -1662,7 +1690,9 @@ class MusicService :
                         } else {
                             incomingPlayer.pause()
                         }
+                        crossfadeIncomingPosition.value = incomingPlayer.currentPosition
                         lastTickMs = nowMs
+
                         delay(CROSSFADE_FRAME_MS)
                     }
 
@@ -1725,9 +1755,13 @@ class MusicService :
         currentMediaMetadata.value = player.getMediaItemAt(targetIndex).metadata
 
         isCrossfading = false
+        isCrossfadingState.value = false
         crossfadeHandoffInProgress = false
         crossfadeProgress = 0f
         crossfadePlaybackRequested = false
+        crossfadeIncomingPosition.value = -1L
+        crossfadeRestoreMetadataOnCancel = false
+        previousCrossfadeMetadata = null
         releaseSecondaryCrossfadePlayer()
         applyEffectiveVolume()
         scheduleCrossfade()
@@ -1814,9 +1848,17 @@ class MusicService :
         crossfadeJob?.cancel()
         crossfadeJob = null
         isCrossfading = false
+        isCrossfadingState.value = false
         crossfadeHandoffInProgress = false
         crossfadeProgress = 0f
         crossfadePlaybackRequested = false
+        crossfadeIncomingPosition.value = -1L
+        // Restore old metadata if crossfade was cancelled before handoff
+        if (crossfadeRestoreMetadataOnCancel) {
+            crossfadeRestoreMetadataOnCancel = false
+            previousCrossfadeMetadata?.let { currentMediaMetadata.value = it }
+            previousCrossfadeMetadata = null
+        }
         if (::player.isInitialized && resetPauseAtEnd) {
             player.pauseAtEndOfMediaItems = false
         }
@@ -4422,8 +4464,10 @@ class MusicService :
         }
     }
 
-    val timelineEmpty = player.currentTimeline.isEmpty || player.mediaItemCount == 0 || player.currentMediaItem == null
-    currentMediaMetadata.value = if (timelineEmpty) null else (mediaItem?.metadata ?: player.currentMetadata)
+    if (!crossfadeHandoffInProgress) {
+        val timelineEmpty = player.currentTimeline.isEmpty || player.mediaItemCount == 0 || player.currentMediaItem == null
+        currentMediaMetadata.value = if (timelineEmpty) null else (mediaItem?.metadata ?: player.currentMetadata)
+    }
 
     widgetUpdater.update()
 

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
@@ -214,6 +214,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -410,14 +411,16 @@ class MusicService :
     private var secondaryCrossfadePlayer: ExoPlayer? = null
     private var secondaryCrossfadeTarget: CrossfadeTarget? = null
     private var isCrossfading = false
-    val isCrossfadingState = MutableStateFlow(false)
+    private val _isCrossfadingState = MutableStateFlow(false)
+    val isCrossfadingState = _isCrossfadingState.asStateFlow()
     private var crossfadeHandoffInProgress = false
     private var crossfadeBaseVolume = 1f
     private var crossfadeProgress = 0f
     private var crossfadePlaybackRequested = false
     private var previousCrossfadeMetadata: moe.koiverse.archivetune.models.MediaMetadata? = null
     private var crossfadeRestoreMetadataOnCancel = false
-    val crossfadeIncomingPosition = MutableStateFlow(-1L)
+    private val _crossfadeIncomingPosition = MutableStateFlow(-1L)
+    val crossfadeIncomingPosition = _crossfadeIncomingPosition.asStateFlow()
     private var lyricsPreloadManager: LyricsPreloadManager? = null
 
     private val secondaryCrossfadeListener =
@@ -1636,7 +1639,7 @@ class MusicService :
         crossfadeJob =
             scope.launch {
                 isCrossfading = true
-                isCrossfadingState.value = true
+                _isCrossfadingState.value = true
                 crossfadeProgress = 0f
                 crossfadeBaseVolume = currentEffectivePlayerVolume()
                 crossfadePlaybackRequested = player.playWhenReady
@@ -1659,7 +1662,7 @@ class MusicService :
                     // Update metadata to the incoming song immediately
                     previousCrossfadeMetadata = currentMediaMetadata.value
                     crossfadeRestoreMetadataOnCancel = true
-                    player.getMediaItemAt(target.index).metadata?.let { incomingMediaMetadata ->
+                    incomingPlayer.currentMediaItem?.metadata?.let { incomingMediaMetadata ->
                         currentMediaMetadata.value = incomingMediaMetadata
                     }
 
@@ -1677,6 +1680,7 @@ class MusicService :
                     var lastTickMs = android.os.SystemClock.elapsedRealtime()
                     while (isActive && elapsedMs < durationMs) {
                         if (player.currentMediaItem?.mediaId != outgoingMediaId) {
+                            crossfadeRestoreMetadataOnCancel = false
                             cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
                             return@launch
                         }
@@ -1690,7 +1694,7 @@ class MusicService :
                         } else {
                             incomingPlayer.pause()
                         }
-                        crossfadeIncomingPosition.value = incomingPlayer.currentPosition
+                        _crossfadeIncomingPosition.value = incomingPlayer.currentPosition
                         lastTickMs = nowMs
 
                         delay(CROSSFADE_FRAME_MS)
@@ -1755,88 +1759,16 @@ class MusicService :
         currentMediaMetadata.value = player.getMediaItemAt(targetIndex).metadata
 
         isCrossfading = false
-        isCrossfadingState.value = false
+        _isCrossfadingState.value = false
         crossfadeHandoffInProgress = false
         crossfadeProgress = 0f
         crossfadePlaybackRequested = false
-        crossfadeIncomingPosition.value = -1L
+        _crossfadeIncomingPosition.value = -1L
         crossfadeRestoreMetadataOnCancel = false
         previousCrossfadeMetadata = null
         releaseSecondaryCrossfadePlayer()
         applyEffectiveVolume()
         scheduleCrossfade()
-    }
-
-    private suspend fun awaitPrimaryCrossfadeHandoffReady(
-        incomingPlayer: ExoPlayer,
-    ): Boolean {
-        val deadlineMs = android.os.SystemClock.elapsedRealtime() + CROSSFADE_HANDOFF_READY_TIMEOUT_MS
-        while (kotlinx.coroutines.currentCoroutineContext().isActive && android.os.SystemClock.elapsedRealtime() < deadlineMs) {
-            if (player.playbackState == Player.STATE_READY && canHandoffWithoutRebuffer(incomingPlayer)) {
-                return true
-            }
-            if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
-                return false
-            }
-            delay(25L)
-        }
-        return player.playbackState == Player.STATE_READY && canHandoffWithoutRebuffer(incomingPlayer)
-    }
-
-    private fun canHandoffWithoutRebuffer(incomingPlayer: ExoPlayer): Boolean {
-        if (player.currentMediaItem?.localConfiguration?.uri?.shouldBypassPlayerCache() == true) return true
-        if (hasBufferedForSmoothStart(player, CROSSFADE_HANDOFF_BUFFER_MS)) {
-            val bufferedPosition = player.bufferedPosition
-            val incomingPosition = incomingPlayer.currentPosition.coerceAtLeast(0L)
-            return bufferedPosition == C.TIME_UNSET ||
-                incomingPosition + CROSSFADE_HANDOFF_SEEK_GUARD_MS <= bufferedPosition
-        }
-        return false
-    }
-
-    private fun requiredCrossfadeStartBufferMs(durationMs: Long): Long =
-        (durationMs + CROSSFADE_HANDOFF_BUFFER_MS)
-            .coerceAtLeast(CROSSFADE_MIN_BUFFER_BEFORE_START_MS)
-            .coerceAtMost(CROSSFADE_MAX_BUFFER_BEFORE_START_MS)
-
-    private fun hasBufferedForSmoothStart(
-        targetPlayer: ExoPlayer,
-        minimumBufferedMs: Long,
-    ): Boolean {
-        if (minimumBufferedMs <= 0L) return true
-        if (targetPlayer.currentMediaItem?.localConfiguration?.uri?.shouldBypassPlayerCache() == true) return true
-
-        val duration = targetPlayer.duration
-        val currentPosition = targetPlayer.currentPosition.coerceAtLeast(0L)
-        val remainingDuration =
-            if (duration != C.TIME_UNSET && duration > currentPosition) {
-                duration - currentPosition
-            } else {
-                Long.MAX_VALUE
-            }
-        val requiredBufferedMs = minimumBufferedMs.coerceAtMost(remainingDuration)
-        if (requiredBufferedMs <= 0L) return true
-
-        val bufferedDuration = targetPlayer.totalBufferedDuration.coerceAtLeast(0L)
-        if (bufferedDuration >= requiredBufferedMs) return true
-
-        return duration != C.TIME_UNSET &&
-            targetPlayer.bufferedPosition >= duration - CROSSFADE_END_GUARD_MS
-    }
-
-    private fun resolveCrossfadeTargetIndex(target: CrossfadeTarget): Int {
-        if (target.index in 0 until player.mediaItemCount &&
-            player.getMediaItemAt(target.index).mediaId == target.mediaId
-        ) {
-            return target.index
-        }
-
-        for (index in 0 until player.mediaItemCount) {
-            if (player.getMediaItemAt(index).mediaId == target.mediaId) {
-                return index
-            }
-        }
-        return C.INDEX_UNSET
     }
 
     private fun cancelCrossfade(
@@ -1848,11 +1780,11 @@ class MusicService :
         crossfadeJob?.cancel()
         crossfadeJob = null
         isCrossfading = false
-        isCrossfadingState.value = false
+        _isCrossfadingState.value = false
         crossfadeHandoffInProgress = false
         crossfadeProgress = 0f
         crossfadePlaybackRequested = false
-        crossfadeIncomingPosition.value = -1L
+        _crossfadeIncomingPosition.value = -1L
         // Restore old metadata if crossfade was cancelled before handoff
         if (crossfadeRestoreMetadataOnCancel) {
             crossfadeRestoreMetadataOnCancel = false
@@ -4464,8 +4396,8 @@ class MusicService :
         }
     }
 
+    val timelineEmpty = player.currentTimeline.isEmpty || player.mediaItemCount == 0 || player.currentMediaItem == null
     if (!crossfadeHandoffInProgress) {
-        val timelineEmpty = player.currentTimeline.isEmpty || player.mediaItemCount == 0 || player.currentMediaItem == null
         currentMediaMetadata.value = if (timelineEmpty) null else (mediaItem?.metadata ?: player.currentMetadata)
     }
 
@@ -4947,6 +4879,7 @@ private fun onMediaItemTransitionInternal() {
             reason == Player.DISCONTINUITY_REASON_SEEK || reason == Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT
         if (isSeekDiscontinuity) {
             if (!crossfadeHandoffInProgress) {
+                crossfadeRestoreMetadataOnCancel = false
                 cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
             }
         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
@@ -59,6 +59,8 @@ class PlayerConnection(
             SharingStarted.Lazily,
             player.playWhenReady && player.playbackState != STATE_ENDED
         )
+    val isCrossfading = service.isCrossfadingState
+    val crossfadeIncomingPosition = service.crossfadeIncomingPosition
     val mediaMetadata = service.currentMediaMetadata
     val currentSong =
         mediaMetadata.flatMapLatest {

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
@@ -33,6 +33,7 @@ import moe.koiverse.archivetune.utils.reportException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
@@ -59,8 +60,8 @@ class PlayerConnection(
             SharingStarted.Lazily,
             player.playWhenReady && player.playbackState != STATE_ENDED
         )
-    val isCrossfading = service.isCrossfadingState
-    val crossfadeIncomingPosition = service.crossfadeIncomingPosition
+    val isCrossfading: StateFlow<Boolean> = service.isCrossfadingState
+    val crossfadeIncomingPosition: StateFlow<Long> = service.crossfadeIncomingPosition
     val mediaMetadata = service.currentMediaMetadata
     val currentSong =
         mediaMetadata.flatMapLatest {

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
@@ -562,10 +562,8 @@ fun Queue(
         var shouldScrollToCurrent by remember { mutableStateOf(false) }
         var lastScrolledUid by remember { mutableStateOf<Long?>(null) }
 
-        val currentPlayingUid = remember(currentWindowIndex, queueWindows) {
-            if (currentWindowIndex in queueWindows.indices) {
-                queueWindows[currentWindowIndex].uid
-            } else null
+        val currentPlayingMediaId = remember(mediaMetadata) {
+            mediaMetadata?.id
         }
 
         val reorderableState = rememberReorderableLazyListState(
@@ -615,9 +613,9 @@ fun Queue(
             }
         }
 
-        LaunchedEffect(currentPlayingUid, shouldScrollToCurrent) {
-            if (currentPlayingUid != null && shouldScrollToCurrent) {
-                val indexInMutableList = mutableQueueWindows.indexOfFirst { it.uid == currentPlayingUid }
+        LaunchedEffect(currentPlayingMediaId, shouldScrollToCurrent) {
+            if (currentPlayingMediaId != null && shouldScrollToCurrent) {
+                val indexInMutableList = mutableQueueWindows.indexOfFirst { it.mediaItem.mediaId == currentPlayingMediaId }
                 if (indexInMutableList != -1) {
                     lazyListState.scrollToItem(indexInMutableList + 1)
                 }
@@ -656,8 +654,8 @@ fun Queue(
         }
 
         LaunchedEffect(state.isCollapsed) {
-            if (!state.isCollapsed && currentPlayingUid != null) {
-                val indexInMutableList = mutableQueueWindows.indexOfFirst { it.uid == currentPlayingUid }
+            if (!state.isCollapsed && currentPlayingMediaId != null) {
+                val indexInMutableList = mutableQueueWindows.indexOfFirst { it.mediaItem.mediaId == currentPlayingMediaId }
                 if (indexInMutableList != -1) {
                     // Scroll to the item + headerItems (Spacer)
                     // The Spacer is at index 0, so the first song is at index 1.
@@ -769,7 +767,7 @@ fun Queue(
                         key = window.uid.hashCode(),
                     ) {
                         val currentItem by rememberUpdatedState(window)
-                        val isActive = window.uid == currentPlayingUid
+                        val isActive = window.mediaItem.mediaId == currentPlayingMediaId
                         val dismissBoxState =
                             rememberSwipeToDismissBoxState(
                                 positionalThreshold = { totalDistance -> totalDistance }


### PR DESCRIPTION
### Summary

When crossfade begins, metadata (title, artist, cover art, queue highlight, notification, Discord RPC) now **immediately** switches to the incoming song instead of waiting until the audio fade completes.

### Changes

**MusicService.kt**
- `startCrossfade()`: update `currentMediaMetadata` to the incoming song right after the secondary player is ready
- Save previous metadata to restore if crossfade is cancelled before handoff
- Guard `onMediaItemTransition()` from overwriting metadata during `crossfadeHandoffInProgress`
- Expose `isCrossfadingState` and `crossfadeIncomingPosition` as StateFlow
- Discord RPC: song provider prefers `currentMediaMetadata` when crossfading; triggers immediate restart
- Force `refreshPlaybackNotification()` on crossfade start
- Track incoming player's position during crossfade loop for seek bar accuracy

**PlayerConnection.kt**
- Expose `isCrossfading: StateFlow<Boolean>` and `crossfadeIncomingPosition: StateFlow<Long>`

**Queue.kt**
- Replace `currentPlayingUid` (based on `currentWindowIndex`) with `currentPlayingMediaId` (based on `mediaMetadata?.id`)
- `isActive` highlight now compares `window.mediaItem.mediaId` so the queue correctly highlights the incoming song during crossfade

### Components affected

| Component | Behavior |
|---|---|
| Player UI | Title, artist, cover art, gradient background update immediately |
| MiniPlayer | Song info updates immediately via `mediaMetadata` StateFlow |
| Queue | Highlight switches to incoming song |
| Lyrics Screen | Lyrics load for the incoming song |
| Notification | Custom layout updates (title/artist via Media3 session) |
| Discord RPC | Presence updates to the incoming song immediately |

### Edge cases handled

- **Crossfade cancelled mid-way**: metadata restores to the previous song
- **Handoff seek**: `onMediaItemTransition` does not overwrite the already-correct metadata
- **Position during crossfade**: seek bar shows elapsed time since crossfade start (existing `isTransitioning` logic)