### PR TITLE
feat: add Follow App Language option for content language & country

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
@@ -137,11 +137,37 @@ class App : Application(), SingletonImageLoader.Factory {
             try {
                 val prefs = dataStore.data.first()
                 
-                prefs[ContentCountryKey]?.takeIf { it != SYSTEM_DEFAULT }?.let { country ->
-                    YouTube.locale = YouTube.locale.copy(gl = country)
+                val appLanguage = prefs[AppLanguageKey] ?: SYSTEM_DEFAULT
+
+                prefs[ContentCountryKey]?.let { country ->
+                    val effectiveCountry = when (country) {
+                        SYSTEM_DEFAULT -> null
+                        FOLLOW_APP_LANGUAGE -> {
+                            when (appLanguage) {
+                                SYSTEM_DEFAULT -> null
+                                else -> resolveContentCountry(appLanguage)
+                            }
+                        }
+                        else -> country
+                    }
+                    effectiveCountry?.let { gl ->
+                        YouTube.locale = YouTube.locale.copy(gl = gl)
+                    }
                 }
-                prefs[ContentLanguageKey]?.takeIf { it != SYSTEM_DEFAULT }?.let { lang ->
-                    YouTube.locale = YouTube.locale.copy(hl = lang)
+                prefs[ContentLanguageKey]?.let { lang ->
+                    val effectiveLang = when (lang) {
+                        SYSTEM_DEFAULT -> null
+                        FOLLOW_APP_LANGUAGE -> {
+                            when (appLanguage) {
+                                SYSTEM_DEFAULT -> null
+                                else -> appLanguage
+                            }
+                        }
+                        else -> lang
+                    }
+                    effectiveLang?.let { hl ->
+                        YouTube.locale = YouTube.locale.copy(hl = hl)
+                    }
                 }
                 
                 LastFM.sessionKey = prefs[LastFMSessionKey]

--- a/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
@@ -139,36 +139,18 @@ class App : Application(), SingletonImageLoader.Factory {
                 
                 val appLanguage = prefs[AppLanguageKey] ?: SYSTEM_DEFAULT
 
-                prefs[ContentCountryKey]?.let { country ->
-                    val effectiveCountry = when (country) {
-                        SYSTEM_DEFAULT -> null
-                        FOLLOW_APP_LANGUAGE -> {
-                            when (appLanguage) {
-                                SYSTEM_DEFAULT -> null
-                                else -> resolveContentCountry(appLanguage)
-                            }
-                        }
-                        else -> country
+                prefs[ContentCountryKey]?.takeUnless { it == SYSTEM_DEFAULT }
+                    ?.let { country ->
+                        YouTube.locale = YouTube.locale.copy(
+                            gl = if (country == FOLLOW_APP_LANGUAGE) resolveContentCountry(appLanguage) else country
+                        )
                     }
-                    effectiveCountry?.let { gl ->
-                        YouTube.locale = YouTube.locale.copy(gl = gl)
+                prefs[ContentLanguageKey]?.takeUnless { it == SYSTEM_DEFAULT }
+                    ?.let { lang ->
+                        YouTube.locale = YouTube.locale.copy(
+                            hl = if (lang == FOLLOW_APP_LANGUAGE) resolveContentLanguage(appLanguage) else lang
+                        )
                     }
-                }
-                prefs[ContentLanguageKey]?.let { lang ->
-                    val effectiveLang = when (lang) {
-                        SYSTEM_DEFAULT -> null
-                        FOLLOW_APP_LANGUAGE -> {
-                            when (appLanguage) {
-                                SYSTEM_DEFAULT -> null
-                                else -> appLanguage
-                            }
-                        }
-                        else -> lang
-                    }
-                    effectiveLang?.let { hl ->
-                        YouTube.locale = YouTube.locale.copy(hl = hl)
-                    }
-                }
                 
                 LastFM.sessionKey = prefs[LastFMSessionKey]
 

--- a/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
@@ -133,6 +133,62 @@ enum class SliderStyle {
 }
 
 const val SYSTEM_DEFAULT = "SYSTEM_DEFAULT"
+const val FOLLOW_APP_LANGUAGE = "FOLLOW_APP_LANGUAGE"
+
+fun resolveContentCountry(appLanguage: String): String {
+    if (appLanguage == SYSTEM_DEFAULT) {
+        return java.util.Locale.getDefault().country
+            .takeIf { it in CountryCodeToName } ?: "US"
+    }
+    val locale = java.util.Locale.forLanguageTag(appLanguage)
+    return locale.country.takeIf { it.isNotEmpty() && it in CountryCodeToName }
+        ?: LanguageCodeToDefaultCountry[locale.language]
+        ?: "US"
+}
+
+val LanguageCodeToDefaultCountry =
+    mapOf(
+        "en" to "US",
+        "en-GB" to "GB",
+        "ja" to "JP",
+        "ko" to "KR",
+        "vi" to "VN",
+        "zh" to "CN",
+        "zh-CN" to "CN",
+        "zh-TW" to "TW",
+        "fr" to "FR",
+        "de" to "DE",
+        "es" to "ES",
+        "pt" to "PT",
+        "pt-BR" to "BR",
+        "ru" to "RU",
+        "it" to "IT",
+        "nl" to "NL",
+        "pl" to "PL",
+        "tr" to "TR",
+        "ar" to "SA",
+        "hi" to "IN",
+        "th" to "TH",
+        "id" to "ID",
+        "ms" to "MY",
+        "uk" to "UA",
+        "cs" to "CZ",
+        "el" to "GR",
+        "he" to "IL",
+        "hu" to "HU",
+        "ro" to "RO",
+        "fi" to "FI",
+        "da" to "DK",
+        "no" to "NO",
+        "sv" to "SE",
+        "sk" to "SK",
+        "bg" to "BG",
+        "hr" to "HR",
+        "sr" to "RS",
+        "lt" to "LT",
+        "lv" to "LV",
+        "et" to "EE",
+    )
 
 enum class PlaylistSuggestionSource {
     PLAYLIST_TITLE,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
@@ -135,6 +135,19 @@ enum class SliderStyle {
 const val SYSTEM_DEFAULT = "SYSTEM_DEFAULT"
 const val FOLLOW_APP_LANGUAGE = "FOLLOW_APP_LANGUAGE"
 
+fun resolveContentLanguage(appLanguage: String): String {
+    val languageTag = java.util.Locale.getDefault().toLanguageTag().replace("-Hant", "")
+    val systemLang = java.util.Locale.getDefault().language
+    val systemTag = languageTag
+    val effective = when {
+        appLanguage != SYSTEM_DEFAULT -> appLanguage
+        systemLang in LanguageCodeToName -> systemLang
+        systemTag in LanguageCodeToName -> systemTag
+        else -> "en"
+    }
+    return effective
+}
+
 fun resolveContentCountry(appLanguage: String): String {
     if (appLanguage == SYSTEM_DEFAULT) {
         return java.util.Locale.getDefault().country

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/ContentSettings.kt
@@ -83,21 +83,35 @@ fun ContentSettings(
                     title = { Text(stringResource(R.string.content_language)) },
                     icon = { Icon(painterResource(R.drawable.language), null) },
                     selectedValue = contentLanguage,
-                    values = listOf(SYSTEM_DEFAULT) + LanguageCodeToName.keys.toList(),
+                    values = listOf(FOLLOW_APP_LANGUAGE, SYSTEM_DEFAULT) + LanguageCodeToName.keys.toList(),
                     valueText = {
-                        LanguageCodeToName.getOrElse(it) { stringResource(R.string.system_default) }
+                        when (it) {
+                            FOLLOW_APP_LANGUAGE -> stringResource(R.string.follow_app_language)
+                            SYSTEM_DEFAULT -> stringResource(R.string.system_default)
+                            else -> LanguageCodeToName[it] ?: it
+                        }
                     },
                     onValueSelected = { newValue ->
-                        val locale = Locale.getDefault()
-                        val languageTag = locale.toLanguageTag().replace("-Hant", "")
-
-                        YouTube.locale = YouTube.locale.copy(
-                            hl = newValue.takeIf { it != SYSTEM_DEFAULT }
-                                ?: locale.language.takeIf { it in LanguageCodeToName }
-                                ?: languageTag.takeIf { it in LanguageCodeToName }
-                                ?: "en"
-                        )
-
+                        val effectiveHl = when (newValue) {
+                            FOLLOW_APP_LANGUAGE -> {
+                                if (appLanguage == SYSTEM_DEFAULT) {
+                                    val locale = Locale.getDefault()
+                                    val languageTag = locale.toLanguageTag().replace("-Hant", "")
+                                    locale.language.takeIf { it in LanguageCodeToName }
+                                        ?: languageTag.takeIf { it in LanguageCodeToName }
+                                        ?: "en"
+                                } else appLanguage
+                            }
+                            SYSTEM_DEFAULT -> {
+                                val locale = Locale.getDefault()
+                                val languageTag = locale.toLanguageTag().replace("-Hant", "")
+                                locale.language.takeIf { it in LanguageCodeToName }
+                                    ?: languageTag.takeIf { it in LanguageCodeToName }
+                                    ?: "en"
+                            }
+                            else -> newValue
+                        }
+                        YouTube.locale = YouTube.locale.copy(hl = effectiveHl)
                         onContentLanguageChange(newValue)
                     }
                 )
@@ -108,19 +122,24 @@ fun ContentSettings(
                     title = { Text(stringResource(R.string.content_country)) },
                     icon = { Icon(painterResource(R.drawable.location_on), null) },
                     selectedValue = contentCountry,
-                    values = listOf(SYSTEM_DEFAULT) + CountryCodeToName.keys.toList(),
+                    values = listOf(FOLLOW_APP_LANGUAGE, SYSTEM_DEFAULT) + CountryCodeToName.keys.toList(),
                     valueText = {
-                        CountryCodeToName.getOrElse(it) { stringResource(R.string.system_default) }
+                        when (it) {
+                            FOLLOW_APP_LANGUAGE -> stringResource(R.string.follow_app_language)
+                            SYSTEM_DEFAULT -> stringResource(R.string.system_default)
+                            else -> CountryCodeToName[it] ?: it
+                        }
                     },
                     onValueSelected = { newValue ->
-                        val locale = Locale.getDefault()
-
-                        YouTube.locale = YouTube.locale.copy(
-                            gl = newValue.takeIf { it != SYSTEM_DEFAULT }
-                                ?: locale.country.takeIf { it in CountryCodeToName }
-                                ?: "US"
-                        )
-
+                        val effectiveGl = when (newValue) {
+                            FOLLOW_APP_LANGUAGE -> resolveContentCountry(appLanguage)
+                            SYSTEM_DEFAULT -> {
+                                Locale.getDefault().country.takeIf { it in CountryCodeToName }
+                                    ?: "US"
+                            }
+                            else -> newValue
+                        }
+                        YouTube.locale = YouTube.locale.copy(gl = effectiveGl)
                         onContentCountryChange(newValue)
                     }
                 )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/ContentSettings.kt
@@ -92,26 +92,10 @@ fun ContentSettings(
                         }
                     },
                     onValueSelected = { newValue ->
-                        val effectiveHl = when (newValue) {
-                            FOLLOW_APP_LANGUAGE -> {
-                                if (appLanguage == SYSTEM_DEFAULT) {
-                                    val locale = Locale.getDefault()
-                                    val languageTag = locale.toLanguageTag().replace("-Hant", "")
-                                    locale.language.takeIf { it in LanguageCodeToName }
-                                        ?: languageTag.takeIf { it in LanguageCodeToName }
-                                        ?: "en"
-                                } else appLanguage
-                            }
-                            SYSTEM_DEFAULT -> {
-                                val locale = Locale.getDefault()
-                                val languageTag = locale.toLanguageTag().replace("-Hant", "")
-                                locale.language.takeIf { it in LanguageCodeToName }
-                                    ?: languageTag.takeIf { it in LanguageCodeToName }
-                                    ?: "en"
-                            }
-                            else -> newValue
-                        }
-                        YouTube.locale = YouTube.locale.copy(hl = effectiveHl)
+                        YouTube.locale = YouTube.locale.copy(
+                            hl = newValue.takeUnless { it == SYSTEM_DEFAULT || it == FOLLOW_APP_LANGUAGE }
+                                ?: resolveContentLanguage(appLanguage)
+                        )
                         onContentLanguageChange(newValue)
                     }
                 )
@@ -131,15 +115,10 @@ fun ContentSettings(
                         }
                     },
                     onValueSelected = { newValue ->
-                        val effectiveGl = when (newValue) {
-                            FOLLOW_APP_LANGUAGE -> resolveContentCountry(appLanguage)
-                            SYSTEM_DEFAULT -> {
-                                Locale.getDefault().country.takeIf { it in CountryCodeToName }
-                                    ?: "US"
-                            }
-                            else -> newValue
-                        }
-                        YouTube.locale = YouTube.locale.copy(gl = effectiveGl)
+                        YouTube.locale = YouTube.locale.copy(
+                            gl = newValue.takeUnless { it == SYSTEM_DEFAULT || it == FOLLOW_APP_LANGUAGE }
+                                ?: resolveContentCountry(appLanguage)
+                        )
                         onContentCountryChange(newValue)
                     }
                 )
@@ -217,6 +196,13 @@ fun ContentSettings(
 
                             onAppLanguageChange(langTag)
                             setAppLocale(context, newLocale)
+
+                            if (contentLanguage == FOLLOW_APP_LANGUAGE) {
+                                YouTube.locale = YouTube.locale.copy(hl = resolveContentLanguage(langTag))
+                            }
+                            if (contentCountry == FOLLOW_APP_LANGUAGE) {
+                                YouTube.locale = YouTube.locale.copy(gl = resolveContentCountry(langTag))
+                            }
                         }
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,6 +463,7 @@
     <string name="content_language">Default content language</string>
     <string name="content_country">Default content country</string>
     <string name="system_default">System default</string>
+    <string name="follow_app_language">Follow App Language</string>
     <string name="enable_proxy">Enable proxy</string>
     <string name="internet">Internet</string>
     <string name="internet_warning_title">Security &amp; Usage Warning</string>


### PR DESCRIPTION
Add a new "Follow App Language" option to both **Default content language** and **Default content country** settings.

### Changes

- **PreferenceKeys.kt**: Added `FOLLOW_APP_LANGUAGE` constant, `resolveContentCountry()` helper function, and `LanguageCodeToDefaultCountry` mapping
- **ContentSettings.kt**: Both content language and country list preferences now include `Follow App Language` as the first option; resolves the effective value from the current app language setting
- **App.kt**: Deferred initialization handles `FOLLOW_APP_LANGUAGE` for both content language and country
- **strings.xml**: Added `follow_app_language` string resource

When `Follow App Language` is selected, content language mirrors the app language value, and content country is derived from the app language tag (via region code or default mapping).