### PR TITLE
feat(i18n): add Vietnamese and Japanese translations + extract hardcoded strings

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
@@ -147,7 +147,7 @@ class App : Application(), SingletonImageLoader.Factory {
                         YouTube.proxyPassword = prefs[ProxyPasswordKey]
                     } catch (e: Exception) {
                         withContext(Dispatchers.Main) {
-                            Toast.makeText(this@App, "Failed to parse proxy settings.", LENGTH_SHORT).show()
+                            Toast.makeText(this@App, context.getString(R.string.failed_to_parse_proxy), LENGTH_SHORT).show()
                         }
                         reportException(e)
                     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
@@ -147,7 +147,7 @@ class App : Application(), SingletonImageLoader.Factory {
                         YouTube.proxyPassword = prefs[ProxyPasswordKey]
                     } catch (e: Exception) {
                         withContext(Dispatchers.Main) {
-                            Toast.makeText(this@App, context.getString(R.string.failed_to_parse_proxy), LENGTH_SHORT).show()
+                            Toast.makeText(this@App, this@App.getString(R.string.failed_to_parse_proxy), LENGTH_SHORT).show()
                         }
                         reportException(e)
                     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/DebugActivity.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/DebugActivity.kt
@@ -69,8 +69,8 @@ class DebugActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val stack = intent.getStringExtra(EXTRA_STACK_TRACE) ?: "No stack trace available"
-        val previewText = stack.lineSequence().firstOrNull()?.take(100) ?: "Unknown error"
+        val stack = intent.getStringExtra(EXTRA_STACK_TRACE) ?: getString(R.string.no_stack_trace)
+        val previewText = stack.lineSequence().firstOrNull()?.take(100) ?: getString(R.string.unknown_error)
         val timestampText = runCatching {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
         }.getOrDefault("")
@@ -128,7 +128,7 @@ private fun CrashReportScreen(
                     type = "text/plain"
                     putExtra(Intent.EXTRA_TEXT, reportText)
                 }
-                context.startActivity(Intent.createChooser(share, "Share crash log"))
+                context.startActivity(Intent.createChooser(share, context.getString(R.string.share_crash_log)))
             },
             onRestart = onRestart,
             onClose = onClose,
@@ -160,14 +160,14 @@ private fun CrashReportScaffold(
                         contentDescription = null,
                     )
                 },
-                text = { Text("Share Logs") },
+                text = { Text(stringResource(R.string.share_logs)) },
             )
         },
         topBar = {
             TopAppBar(
                 title = {
                     Text(
-                        text = "Crash Report",
+                        text = stringResource(R.string.crash_report),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
@@ -225,7 +225,7 @@ private fun CrashReportScaffold(
                             modifier = Modifier.size(22.dp),
                         )
                         Text(
-                            text = "Application crashed",
+                            text = stringResource(R.string.application_crashed),
                             style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                             color = MaterialTheme.colorScheme.onErrorContainer,
                         )
@@ -260,7 +260,7 @@ private fun CrashReportScaffold(
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     Text(
-                        text = "Device info",
+                        text = stringResource(R.string.device_info),
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                     )
                     deviceInfo.forEachIndexed { index, (k, v) ->
@@ -288,7 +288,7 @@ private fun CrashReportScaffold(
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     Text(
-                        text = "Stack trace",
+                        text = stringResource(R.string.stack_trace),
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                     )
                     SelectionContainer {
@@ -314,7 +314,7 @@ private fun CrashReportScaffold(
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                     shapes = ButtonDefaults.shapes(),
                 ) {
-                    Text("Restart")
+                    Text(stringResource(R.string.restart))
                 }
                 Button(
                     onClick = onClose,
@@ -322,7 +322,7 @@ private fun CrashReportScaffold(
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
                     shapes = ButtonDefaults.shapes(),
                 ) {
-                    Text("Close")
+                    Text(stringResource(R.string.close))
                 }
             }
 
@@ -374,8 +374,8 @@ private fun buildCrashReport(
     }.getOrDefault("")
 
     val header = buildString {
-        appendLine("ArchiveTune crash report")
-        if (timestampText.isNotBlank()) appendLine("Time: $timestampText")
+        appendLine(context.getString(R.string.crash_report_header))
+        if (timestampText.isNotBlank()) appendLine(context.getString(R.string.crash_report_time, timestampText))
         val appVersionLabel = when {
             versionName.isNotBlank() && versionCode.isNotBlank() -> {
                 "${formatVersionName(versionName)} ($versionCode)"
@@ -386,14 +386,14 @@ private fun buildCrashReport(
             else -> null
         }
         if (appVersionLabel != null) {
-            appendLine("App: $appVersionLabel")
+            appendLine(context.getString(R.string.crash_report_app, appVersionLabel))
         }
-        appendLine("Package: $packageName")
+        appendLine(context.getString(R.string.crash_report_package, packageName))
     }
 
     val deviceBlock = buildString {
         appendLine()
-        appendLine("Device")
+        appendLine(context.getString(R.string.crash_report_device_section))
         deviceInfo.forEach { (k, v) ->
             appendLine("$k: $v")
         }
@@ -404,7 +404,7 @@ private fun buildCrashReport(
         append(deviceBlock)
         appendLine()
         appendLine()
-        appendLine("Stack trace")
+        appendLine(context.getString(R.string.crash_report_stack_trace_section))
         appendLine(stack)
     }
 }
@@ -421,7 +421,7 @@ private fun buildDeviceInfo(
                 ?.takeIf { it.isNotBlank() }
             ?: Build.DEVICE
 
-    val osVersion = "Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})"
+    val osVersion = context.getString(R.string.device_os_version_value, Build.VERSION.RELEASE, Build.VERSION.SDK_INT)
 
     val manufacturer = Build.MANUFACTURER.orEmpty().ifBlank { "-" }
     val brand = Build.BRAND.orEmpty().ifBlank { "-" }
@@ -432,14 +432,14 @@ private fun buildDeviceInfo(
     val fingerprint = Build.FINGERPRINT.orEmpty().ifBlank { "-" }
 
     return listOf(
-        "OS version" to osVersion,
-        "Phone name" to deviceName,
-        "Model" to model,
-        "Manufacturer" to manufacturer,
-        "Brand" to brand,
-        "Device" to Build.DEVICE.orEmpty().ifBlank { "-" },
-        "Product" to product,
-        "Hardware" to hardware,
-        "Fingerprint" to fingerprint,
+        context.getString(R.string.device_os_version) to osVersion,
+        context.getString(R.string.device_phone_name) to deviceName,
+        context.getString(R.string.device_model) to model,
+        context.getString(R.string.device_manufacturer) to manufacturer,
+        context.getString(R.string.device_brand) to brand,
+        context.getString(R.string.device_device) to Build.DEVICE.orEmpty().ifBlank { "-" },
+        context.getString(R.string.device_product) to product,
+        context.getString(R.string.device_hardware) to hardware,
+        context.getString(R.string.device_fingerprint) to fingerprint,
     )
 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/ArtistSeparatorsDialog.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/ArtistSeparatorsDialog.kt
@@ -208,7 +208,7 @@ private fun SeparatorChip(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "\"$symbol\"",
+                text = stringResource(R.string.separator_display, symbol),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/LyricsV2.kt
@@ -851,7 +851,7 @@ fun LyricsV2(
                 shapes = ButtonDefaults.shapes(),
             ) {
                 Text(
-                    text = "Resume",
+                    text = stringResource(R.string.resume_lyrics),
                     style = MaterialTheme.typography.labelLarge,
                 )
             }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/NetworkStatusBanner.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/NetworkStatusBanner.kt
@@ -62,14 +62,14 @@ fun NetworkStatusBanner(
         when (lastVisibleState) {
             NetworkBannerUiState.Hidden,
             NetworkBannerUiState.Offline -> NetworkBannerVisuals(
-                message = "No internet connection",
+                message = stringResource(R.string.no_internet_connection),
                 icon = Icons.Default.CloudOff,
                 containerColor = Color(0xFF7F1D1D),
                 contentColor = Color.White,
             )
 
             NetworkBannerUiState.BackOnline -> NetworkBannerVisuals(
-                message = "Back online",
+                message = stringResource(R.string.back_online),
                 icon = Icons.Default.CloudDone,
                 containerColor = Color(0xFF1E8E3E),
                 contentColor = Color.White,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/SearchBar.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/SearchBar.kt
@@ -300,9 +300,9 @@ private fun SearchBarInputField(
                     }
                 }
                 .semantics {
-                    contentDescription = "Search"
+                    contentDescription = stringResource(R.string.search_cd)
                     if (active) {
-                        stateDescription = "Suggestions available"
+                        stateDescription = stringResource(R.string.suggestions_available)
                     }
                 }
                 .onKeyEvent {

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/ThumbnailCornerRadiusSelector.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/ThumbnailCornerRadiusSelector.kt
@@ -235,7 +235,7 @@ fun ThumbnailCornerRadiusModal(
                             keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
                             trailingIcon = {
                                 Text(
-                                    text = "dp",
+                                    text = stringResource(R.string.dp_unit),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -259,7 +259,7 @@ fun ThumbnailCornerRadiusModal(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
-                                text = "0",
+                                text = stringResource(R.string.min_radius),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -283,7 +283,7 @@ fun ThumbnailCornerRadiusModal(
                             )
 
                             Text(
-                                text = "45",
+                                text = stringResource(R.string.max_radius),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/AddToPlaylistDialog.kt
@@ -318,14 +318,14 @@ fun AddToPlaylistDialog(
 
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = "Add to playlist",
+                                    text = stringResource(R.string.add_to_playlist),
                                     style = MaterialTheme.typography.titleLarge,
                                     fontWeight = FontWeight.SemiBold,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )
                                 if (selectedPlaylistIds.isNotEmpty()) {
                                     Text(
-                                        text = "${selectedPlaylistIds.size} selected",
+                                        text = stringResource(R.string.n_d_selected, selectedPlaylistIds.size),
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.primary,
                                     )
@@ -523,7 +523,7 @@ fun AddToPlaylistDialog(
                         ) {
                             Text(
                                 text = if (searchQuery.isBlank()) {
-                                    "No playlists yet"
+                                    stringResource(R.string.no_playlists_yet)
                                 } else {
                                     stringResource(R.string.no_matching_playlists)
                                 },
@@ -629,9 +629,9 @@ fun AddToPlaylistDialog(
                                 Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
                                 Text(
                                     text = if (selectedPlaylistIds.size > 1)
-                                        "Add to ${selectedPlaylistIds.size}"
+                                        stringResource(R.string.add_to_n, selectedPlaylistIds.size)
                                     else
-                                        "Add"
+                                        stringResource(R.string.add_to_playlist_short)
                                 )
                             }
                         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/AddToPlaylistDialogOnline.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/AddToPlaylistDialogOnline.kt
@@ -309,21 +309,21 @@ fun AddToPlaylistDialogOnline(
     if (showResultDialog && processingSummary != null) {
         val summary = processingSummary!!
         DefaultDialog(
-            title = { Text("Import Complete") },
+            title = { Text(stringResource(R.string.import_complete)) },
             onDismiss = { showResultDialog = false },
             buttons = {
                 TextButton(onClick = { showResultDialog = false }, shapes = ButtonDefaults.shapes()) {
-                    Text("OK")
+                    Text(stringResource(android.R.string.ok))
                 }
             }
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Total Processed: ${summary.total}")
-                Text("Successfully Imported: ${summary.success}", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                Text(stringResource(R.string.total_processed, summary.total))
+                Text(stringResource(R.string.successfully_imported, summary.success), color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
                 if (summary.failed > 0) {
-                    Text("Failed: ${summary.failed}", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
+                    Text(stringResource(R.string.failed_imports, summary.failed), color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                    Text("Failed Items:", style = MaterialTheme.typography.labelLarge)
+                    Text(stringResource(R.string.failed_items_section), style = MaterialTheme.typography.labelLarge)
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -331,7 +331,7 @@ fun AddToPlaylistDialogOnline(
                     ) {
                         items(summary.failedItems) { title ->
                             Text(
-                                text = "• $title",
+                                text = stringResource(R.string.bullet_item, title),
                                 style = MaterialTheme.typography.bodySmall,
                                 modifier = Modifier.padding(vertical = 2.dp)
                             )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/ImportPlaylistDialog.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/ImportPlaylistDialog.kt
@@ -160,7 +160,7 @@ fun ImportPlaylistDialog(
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
-                        showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: "Unknown error"}")
+                        showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: context.getString(R.string.unknown_error)}")
                         withContext(Dispatchers.Main) {
                             resetState()
                             onDismiss()
@@ -257,7 +257,7 @@ fun ImportPlaylistDialog(
                                 }
                             } catch (e: Exception) {
                                 e.printStackTrace()
-                                showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: "Unknown error"}")
+                                showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: context.getString(R.string.unknown_error)}")
                                 withContext(Dispatchers.Main) {
                                     resetState()
                                     onDismiss()
@@ -305,7 +305,7 @@ fun ImportPlaylistDialog(
                                 }
                             } catch (e: Exception) {
                                 e.printStackTrace()
-                                showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: "Unknown error"}")
+                                showMessage(context.getString(R.string.import_failed) + ": ${e.message ?: context.getString(R.string.unknown_error)}")
                                 withContext(Dispatchers.Main) {
                                     resetState()
                                     onDismiss()

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/LyricsMenu.kt
@@ -395,7 +395,7 @@ fun LyricsMenu(
                                             )
                                             Spacer(Modifier.width(4.dp))
                                             Text(
-                                                text = "Synced",
+                                                text = stringResource(R.string.synced_badge),
                                                 style = MaterialTheme.typography.labelSmall,
                                                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                                             )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/PlayerMenu.kt
@@ -852,7 +852,7 @@ fun PlayerMenu(
                                 Text(
                                     text = stringResource(R.string.tempo_pitch_display,
                                         formatMultiplier(playbackParameters.speed),
-                                        formatMultiplier(playbackParameters.pitch)
+                                        formatMultiplier(playbackParameters.pitch)),
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
@@ -1131,7 +1131,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                                 tempo = preset
                                 applyPlaybackParameters(tempo, pitch)
                             },
-                                    label = { Text(stringResource(R.string.pitch_multiplier, formatMultiplier(preset))) },
+                                    label = { Text(stringResource(R.string.tempo_multiplier, formatMultiplier(preset))) },
                         )
                     }
                 }
@@ -1293,7 +1293,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                                         pitch = preset
                                         applyPlaybackParameters(tempo, pitch)
                                     },
-                            label = { Text(stringResource(R.string.tempo_multiplier, formatMultiplier(preset))) },
+                            label = { Text(stringResource(R.string.pitch_multiplier, formatMultiplier(preset))) },
                                 )
                             }
                         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/PlayerMenu.kt
@@ -850,7 +850,9 @@ fun PlayerMenu(
                             supportingContent = {
                                 val playbackParameters by playerConnection.playbackParameters.collectAsState()
                                 Text(
-                                    text = "x${formatMultiplier(playbackParameters.speed)} • x${formatMultiplier(playbackParameters.pitch)}",
+                                    text = stringResource(R.string.tempo_pitch_display,
+                                        formatMultiplier(playbackParameters.speed),
+                                        formatMultiplier(playbackParameters.pitch)
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
@@ -894,7 +896,7 @@ private fun PlayerVolumeCard(
                 )
 
                 Text(
-                    text = "${(safeVolume * 100).roundToInt()}%",
+                    text = stringResource(R.string.volume_percentage, (safeVolume * 100).roundToInt()),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -1061,7 +1063,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                     )
 
                     Text(
-                        text = "x${formatMultiplier(tempo)}",
+                        text = stringResource(R.string.tempo_multiplier, formatMultiplier(tempo)),
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.End,
                     )
@@ -1129,7 +1131,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                                 tempo = preset
                                 applyPlaybackParameters(tempo, pitch)
                             },
-                            label = { Text("x${formatMultiplier(preset)}") },
+                                    label = { Text(stringResource(R.string.pitch_multiplier, formatMultiplier(preset))) },
                         )
                     }
                 }
@@ -1158,10 +1160,10 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                         when (pitchMode) {
                             PitchMode.Semitones -> {
                                 val semitones = pitchToSemitones(pitch)
-                                "${if (semitones > 0) "+" else ""}$semitones"
+                                stringResource(R.string.semitone_value, semitones)
                             }
 
-                            PitchMode.Multiplier -> "x${formatMultiplier(pitch)}"
+                            PitchMode.Multiplier -> stringResource(R.string.pitch_multiplier, formatMultiplier(pitch))
                         },
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.End,
@@ -1222,7 +1224,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                                         pitch = semitonesToPitch(preset)
                                         applyPlaybackParameters(tempo, pitch)
                                     },
-                                    label = { Text("${if (preset > 0) "+" else ""}$preset") },
+                                    label = { Text(stringResource(R.string.semitone_value, preset)) },
                                 )
                             }
                         }
@@ -1291,7 +1293,7 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
                                         pitch = preset
                                         applyPlaybackParameters(tempo, pitch)
                                     },
-                                    label = { Text("x${formatMultiplier(preset)}") },
+                            label = { Text(stringResource(R.string.tempo_multiplier, formatMultiplier(preset))) },
                                 )
                             }
                         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/SelectionSongsMenu.kt
@@ -240,7 +240,7 @@ fun SelectionSongMenu(
                                 onDismiss()
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = "Selection",
+                                        title = stringResource(R.string.selection_queue_title),
                                         items = songSelection.map { it.toMediaItem() },
                                     ),
                                 )
@@ -261,7 +261,7 @@ fun SelectionSongMenu(
                                 onDismiss()
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = "Selection",
+                                        title = stringResource(R.string.selection_queue_title),
                                         items = songSelection.shuffled().map { it.toMediaItem() },
                                     ),
                                 )
@@ -763,7 +763,7 @@ fun SelectionMediaMetadataMenu(
                                 onDismiss()
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = "Selection",
+                                        title = stringResource(R.string.selection_queue_title),
                                         items = songSelection.map { it.toMediaItem() },
                                     ),
                                 )
@@ -784,7 +784,7 @@ fun SelectionMediaMetadataMenu(
                                 onDismiss()
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = "Selection",
+                                        title = stringResource(R.string.selection_queue_title),
                                         items = songSelection.shuffled().map { it.toMediaItem() },
                                     ),
                                 )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/YouTubePlaylistMenu.kt
@@ -725,7 +725,7 @@ fun YouTubePlaylistMenu(
                                         } catch (e: Exception) {
                                             e.printStackTrace()
                                             withContext(Dispatchers.Main) {
-                                                val errorMsg = context.getString(R.string.import_failed) + ": ${e.message ?: "Unknown error"}"
+                                                val errorMsg = context.getString(R.string.import_failed) + ": ${e.message ?: context.getString(R.string.unknown_error)}"
                                                 if (snackbarHostState != null) {
                                                     snackbarHostState.showSnackbar(errorMsg)
                                                 } else {

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlaybackError.kt
@@ -78,8 +78,8 @@ fun PlaybackError(
             PlaybackErrorKind.Timeout -> fallbackTimeout
             PlaybackErrorKind.NoStream -> fallbackNoStream
             PlaybackErrorKind.MalformedStream -> fallbackMalformedStream
-            PlaybackErrorKind.Decoder -> "$fallbackUnknown (code ${error.errorCode})"
-            PlaybackErrorKind.Http -> "$fallbackUnknown (HTTP $httpCode)"
+            PlaybackErrorKind.Decoder -> stringResource(R.string.playback_error_decoder, fallbackUnknown, error.errorCode)
+            PlaybackErrorKind.Http -> stringResource(R.string.playback_error_http, fallbackUnknown, httpCode)
             PlaybackErrorKind.Unknown -> error.cause?.message?.takeIf { it.isNotBlank() }
                 ?: error.message?.takeIf { it.isNotBlank() }
                 ?: fallbackUnknown

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Player.kt
@@ -2162,7 +2162,7 @@ private fun LittlePlayerContent(
                             label = "little_artists",
                         ) { artistLine ->
                             Text(
-                                text = "by - $artistLine",
+                                text = stringResource(R.string.by_prefix, artistLine),
                                 color = secondaryColor,
                                 style = MaterialTheme.typography.bodyMedium,
                                 maxLines = 1,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlayerComponents.kt
@@ -170,9 +170,9 @@ fun PlayerTitleSection(
                         }
                     },
                     onLongClick = {
-                        val clip = ClipData.newPlainText("Copied Title", title)
+                        val clip = ClipData.newPlainText(context.getString(R.string.copied_title), title)
                         clipboardManager.setPrimaryClip(clip)
-                        Toast.makeText(context, "Copied Title", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, context.getString(R.string.copied_title), Toast.LENGTH_SHORT).show()
                     }
                 ),
         )
@@ -239,9 +239,9 @@ fun PlayerTitleSection(
                         }
                     },
                     onLongClick = {
-                        val clip = ClipData.newPlainText("Copied Artist", annotatedString)
+                        val clip = ClipData.newPlainText(context.getString(R.string.copied_artist), annotatedString)
                         clipboardManager.setPrimaryClip(clip)
-                        Toast.makeText(context, "Copied Artist", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, context.getString(R.string.copied_artist), Toast.LENGTH_SHORT).show()
                     }
                 )
         )
@@ -1847,11 +1847,11 @@ fun PlayerControlsContent(
             {
                 val codec = currentFormat.mimeType.substringAfter("/").uppercase()
                 val label = when {
-                    codec.contains("FLAC") || codec.contains("ALAC") -> "Lossless"
-                    codec.contains("OPUS") -> codec
-                    codec.contains("AAC") -> codec
-                    codec.contains("MP4A") -> "AAC"
-                    codec.contains("VORBIS") -> "Vorbis"
+                    codec.contains("FLAC") || codec.contains("ALAC") -> stringResource(R.string.codec_lossless)
+                    codec.contains("OPUS") -> stringResource(R.string.codec_opus)
+                    codec.contains("AAC") -> stringResource(R.string.codec_aac)
+                    codec.contains("MP4A") -> stringResource(R.string.codec_aac)
+                    codec.contains("VORBIS") -> stringResource(R.string.codec_vorbis)
                     else -> codec
                 }
                 Surface(
@@ -3575,7 +3575,7 @@ fun PlayerBackground(
                         Box(modifier = Modifier.fillMaxSize()) {
                             AsyncImage(
                                 model = thumbnailUrl.highRes(),
-                                contentDescription = "Blurred background",
+                                contentDescription = stringResource(R.string.blurred_background),
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier.fillMaxSize().let {
                                     if (shouldApplyBlur) it.blur(radius = effectiveBlurRadius.dp) else it
@@ -3676,7 +3676,7 @@ fun PlayerBackground(
                         Box(modifier = Modifier.fillMaxSize()) {
                             AsyncImage(
                                 model = thumbnailUrl.highRes(),
-                                contentDescription = "Blurred background",
+                                contentDescription = stringResource(R.string.blurred_background),
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier.fillMaxSize().let {
                                     if (shouldApplyBlur) it.blur(radius = effectiveBlurRadius.dp) else it
@@ -3725,7 +3725,7 @@ fun PlayerBackground(
 
                             AsyncImage(
                                 model = Uri.parse(uri),
-                                contentDescription = "Custom background",
+                                contentDescription = stringResource(R.string.custom_background),
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier.fillMaxSize().let {
                                     if (disableBlur) it else it.blur(radius = blurPx.dp)

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
@@ -539,7 +539,7 @@ fun Queue(
                     val activeDevice = remember(audioManager) {
                         audioManager.getDevices(android.media.AudioManager.GET_DEVICES_OUTPUTS)
                             .firstOrNull { it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP || it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO || it.type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET }
-                            ?.productName?.toString() ?: "Speaker"
+                            ?.productName?.toString() ?: stringResource(R.string.speaker_default)
                     }
                     QueueCollapsedContentV7(
                         showCodecOnPlayer = showCodecOnPlayer,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/NewReleaseScreen.kt
@@ -196,14 +196,14 @@ fun NewReleaseScreen(
                             )
                             Spacer(Modifier.height(16.dp))
                             Text(
-                                text = "New releases are temporarily unavailable",
+                                text = stringResource(R.string.new_releases_unavailable),
                                 style = MaterialTheme.typography.titleLarge,
                                 color = MaterialTheme.colorScheme.onSurface,
                                 textAlign = TextAlign.Center,
                             )
                             Spacer(Modifier.height(8.dp))
                             Text(
-                                text = "ArchiveTune could not load this YouTube Music section. Try again later.",
+                                text = stringResource(R.string.new_releases_unavailable_desc),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/StatsScreen.kt
@@ -1069,7 +1069,7 @@ private fun ListeningByHourChart(
         peakSlot?.let {
             val hour = it % 12
             val adjusted = if (hour == 0) 12 else hour
-            val amPm = if (it < 12) "AM" else "PM"
+            val amPm = if (it < 12) stringResource(R.string.time_am) else stringResource(R.string.time_pm)
             "$adjusted$amPm"
         }
     }
@@ -1135,11 +1135,11 @@ private fun ListeningByHourChart(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Text(text = "12AM", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(text = "6AM", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(text = "12PM", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(text = "6PM", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(text = "12AM", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = stringResource(R.string.time_12am), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = stringResource(R.string.time_6am), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = stringResource(R.string.time_12pm), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = stringResource(R.string.time_6pm), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = stringResource(R.string.time_12am), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -661,7 +661,7 @@ fun ArtistScreen(
                                         val shuffledSongs = librarySongs.shuffled()
                                         playerConnection.playQueue(
                                             ListQueue(
-                                                title = libraryArtist?.artist?.name ?: "Unknown Artist",
+                                                title = libraryArtist?.artist?.name ?: stringResource(R.string.unknown_artist),
                                                 items = shuffledSongs.map { it.toMediaItem() }
                                             )
                                         )
@@ -784,7 +784,7 @@ fun ArtistScreen(
                                             } else {
                                                 playerConnection.playQueue(
                                                     ListQueue(
-                                                        title = libraryArtist?.artist?.name ?: "Unknown Artist",
+                                                        title = libraryArtist?.artist?.name ?: stringResource(R.string.unknown_artist),
                                                         items = librarySongs.map { it.toMediaItem() },
                                                         startIndex = index
                                                     )
@@ -1108,7 +1108,7 @@ fun ArtistScreen(
                 onClick = {
                     viewModel.artistPage?.artist?.shareLink?.let { link ->
                         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                        val clip = ClipData.newPlainText("Artist Link", link)
+                        val clip = ClipData.newPlainText(context.getString(R.string.artist_link_label), link)
                         clipboard.setPrimaryClip(clip)
                         Toast.makeText(context, R.string.link_copied, Toast.LENGTH_SHORT).show()
                     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -495,7 +495,7 @@ fun CachePlaylistScreen(
                                     onCheckedChange = {
                                         playerConnection.playQueue(
                                             ListQueue(
-                                                title = "Cache Songs",
+                                                title = stringResource(R.string.cache_songs_title),
                                                 items = filteredSongs.map { it.item.toMediaItem() },
                                             )
                                         )
@@ -523,7 +523,7 @@ fun CachePlaylistScreen(
                                     onCheckedChange = {
                                         playerConnection.playQueue(
                                             ListQueue(
-                                                title = "Cache Songs",
+                                                title = stringResource(R.string.cache_songs_title),
                                                 items = filteredSongs.shuffled().map { it.item.toMediaItem() },
                                             )
                                         )
@@ -636,7 +636,7 @@ fun CachePlaylistScreen(
                                         } else {
                                             playerConnection.playQueue(
                                                 ListQueue(
-                                                    title = "Cache Songs",
+                                                    title = stringResource(R.string.cache_songs_title),
                                                     items = cachedSongs.map { it.toMediaItem() },
                                                     startIndex = cachedSongs.indexOfFirst { it.id == songWrapper.item.id }
                                                 )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1082,7 +1082,7 @@ fun LocalPlaylistScreen(
                                     ) {
                                         Icon(
                                             painter = painterResource(R.drawable.mix),
-                                            contentDescription = "Start Mix",
+                                            contentDescription = stringResource(R.string.start_mix_cd),
                                             modifier = Modifier.size(24.dp)
                                         )
                                     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -882,7 +882,7 @@ fun OnlinePlaylistScreen(
                                         ) {
                                             Icon(
                                                 painter = painterResource(R.drawable.mix),
-                                                contentDescription = "Start Mix",
+                                                contentDescription = stringResource(R.string.start_mix_cd),
                                                 modifier = Modifier.size(24.dp)
                                             )
                                         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AboutScreen.kt
@@ -429,7 +429,7 @@ fun AboutScreen(
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(
-                    text = "ArchiveTune",
+                    text = stringResource(R.string.app_name),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
@@ -447,7 +447,7 @@ fun AboutScreen(
                 Spacer(Modifier.width(4.dp))
 
                 if (BuildConfig.DEBUG) {
-                    AboutBadge(text = "DEBUG")
+                    AboutBadge(text = stringResource(R.string.about_debug))
                 } else {
                     AboutBadge(text = BuildConfig.ARCHITECTURE.uppercase())
                 }
@@ -456,7 +456,7 @@ fun AboutScreen(
             Spacer(Modifier.height(4.dp))
 
             Text(
-                text = "Koiverse",
+                text = stringResource(R.string.about_koiverse),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.secondary,
             )
@@ -510,7 +510,7 @@ fun AboutScreen(
             Spacer(Modifier.height(16.dp))
 
             SectionHeader(
-                title = "Lead Developer",
+                title = stringResource(R.string.about_lead_developer),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -527,7 +527,7 @@ fun AboutScreen(
             Spacer(Modifier.height(24.dp))
 
             SectionHeader(
-                title = "Collaborators",
+                title = stringResource(R.string.about_collaborators),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -550,7 +550,7 @@ fun AboutScreen(
             Spacer(Modifier.height(24.dp))
 
             SectionHeader(
-                title = "Contributors",
+                title = stringResource(R.string.about_contributors),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -767,7 +767,7 @@ private fun LeadDeveloperCard(
                 member.github?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.github,
-                        contentDescription = "GitHub",
+                        contentDescription = stringResource(R.string.about_github),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -775,7 +775,7 @@ private fun LeadDeveloperCard(
                 member.website?.takeIf { it.isNotBlank() }?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.website,
-                        contentDescription = "Website",
+                        contentDescription = stringResource(R.string.about_website),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -783,7 +783,7 @@ private fun LeadDeveloperCard(
                 member.discord?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.alternate_email,
-                        contentDescription = "Discord",
+                        contentDescription = stringResource(R.string.about_discord),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -857,7 +857,7 @@ private fun CollaboratorCard(
                 member.github?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.github,
-                        contentDescription = "GitHub",
+                        contentDescription = stringResource(R.string.about_github),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -865,7 +865,7 @@ private fun CollaboratorCard(
                 member.website?.takeIf { it.isNotBlank() }?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.website,
-                        contentDescription = "Website",
+                        contentDescription = stringResource(R.string.about_website),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -873,7 +873,7 @@ private fun CollaboratorCard(
                 member.discord?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.alternate_email,
-                        contentDescription = "Discord",
+                        contentDescription = stringResource(R.string.about_discord),
                         onClick = { onOpenUri(url) },
                     )
                 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AccountSettings.kt
@@ -426,7 +426,7 @@ fun AccountSettings(
                     ExpressiveActionRow(
                         icon = painterResource(R.drawable.integration),
                         title = integrationLabel,
-                        subtitle = "Discord, Last.fm, ListenBrainz",
+                        subtitle = stringResource(R.string.integration_subtitle),
                         onClick = { navController.navigate("settings/integration") },
                     )
 
@@ -1161,7 +1161,7 @@ private fun VersionStamp() {
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.60f),
         )
         Text(
-            text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+            text = stringResource(R.string.version_display, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.40f),
         )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -469,7 +469,7 @@ fun AppearanceSettings(
                             PlayerBackgroundStyle.COLORING -> stringResource(R.string.coloring)
                             PlayerBackgroundStyle.BLUR_GRADIENT -> stringResource(R.string.blur_gradient)
                             PlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
-                            PlayerBackgroundStyle.GLOW_ANIMATED -> "Glow Animated"
+                            PlayerBackgroundStyle.GLOW_ANIMATED -> stringResource(R.string.glow_animated)
                         }
                     },
                 )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/DiscordSettings.kt
@@ -1140,7 +1140,7 @@ fun EditablePreference(
         description = description ?: if (value.isEmpty()) defaultValue else value,
         icon = { Icon(painterResource(iconRes), null) },
         trailingContent = {
-            TextButton(onClick = { showDialog = true }, shapes = ButtonDefaults.shapes()) { Text("Edit") }
+            TextButton(onClick = { showDialog = true }, shapes = ButtonDefaults.shapes()) { Text(stringResource(R.string.edit)) }
         }
     )
     if (showDialog) {
@@ -1151,12 +1151,12 @@ fun EditablePreference(
                 TextButton(onClick = {
                     onValueChange(if (text.isBlank()) "" else text)
                     showDialog = false
-                }, shapes = ButtonDefaults.shapes()) { Text("Save") }
+                }, shapes = ButtonDefaults.shapes()) { Text(stringResource(R.string.save)) }
             },
             dismissButton = {
-                TextButton(onClick = { showDialog = false }, shapes = ButtonDefaults.shapes()) { Text("Cancel") }
+                TextButton(onClick = { showDialog = false }, shapes = ButtonDefaults.shapes()) { Text(stringResource(R.string.cancel)) }
             },
-            title = { Text("Edit $title") },
+            title = { Text(stringResource(R.string.edit_dialog_title, title)) },
             text = {
                 TextField(
                     value = text,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/InternetSettings.kt
@@ -338,7 +338,7 @@ fun InternetSettings(
                                         }
                                     }
                                 } catch (e: Exception) {
-                                    testResult = context.getString(R.string.proxy_connection_failed, e.message ?: "Unknown error")
+                                    testResult = context.getString(R.string.proxy_connection_failed, e.message ?: context.getString(R.string.unknown_error))
                                 } finally {
                                     testingProxy = false
                                 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -122,6 +123,7 @@ fun LastFMSettings(
     var loginError by rememberSaveable { mutableStateOf<String?>(null) }
 
     if (showLoginDialog) {
+        val context = LocalContext.current
         var tempUsername by rememberSaveable { mutableStateOf("") }
         var tempPassword by rememberSaveable { mutableStateOf("") }
 
@@ -195,12 +197,12 @@ fun LastFMSettings(
                 TextButton(
                     onClick = {
                         if (tempUsername.isBlank() || tempPassword.isBlank()) {
-                            loginError = "Please enter username and password"
+                            loginError = context.getString(R.string.login_enter_credentials)
                             return@TextButton
                         }
                         
                         if (!LastFM.isInitialized()) {
-                            loginError = "Last.fm API key not configured"
+                            loginError = context.getString(R.string.lastfm_api_key_not_configured)
                             Timber.e("Last.fm API key not configured")
                             return@TextButton
                         }
@@ -232,18 +234,18 @@ fun LastFMSettings(
                                                 // 13 = Invalid method signature
                                                 // 26 = API key suspended
                                                 when (exception.code) {
-                                                    4 -> "Invalid username or password"
-                                                    10 -> "Invalid API key. Please contact the developer."
-                                                    13 -> "Authentication error. Please try again."
-                                                    26 -> "API key suspended. Please contact the developer."
+                                                    4 -> context.getString(R.string.login_invalid_credentials)
+                                                    10 -> context.getString(R.string.login_invalid_api_key)
+                                                    13 -> context.getString(R.string.login_auth_error)
+                                                    26 -> context.getString(R.string.login_api_key_suspended)
                                                     else -> exception.message
                                                 }
                                             }
                                             else -> when {
                                                 exception.message?.contains("network", ignoreCase = true) == true ||
-                                                exception.message?.contains("connect", ignoreCase = true) == true ->
-                                                    "Network error. Check your connection."
-                                                else -> exception.message ?: "Login failed. Please try again."
+                                                    exception.message?.contains("connect", ignoreCase = true) == true ->
+                                                        context.getString(R.string.login_network_error)
+                                                    else -> exception.message ?: context.getString(R.string.login_failed_generic)
                                             }
                                         }
                                         loginError = errorMessage
@@ -304,7 +306,7 @@ fun LastFMSettings(
                         modifier = Modifier.padding(16.dp)
                     ) {
                         Text(
-                            text = "${tempMinTrackDuration}s",
+                            text = stringResource(R.string.seconds_format, tempMinTrackDuration),
                             style = MaterialTheme.typography.bodyLarge,
                             modifier = Modifier.padding(bottom = 16.dp)
                         )
@@ -359,7 +361,7 @@ fun LastFMSettings(
                         modifier = Modifier.padding(16.dp)
                     ) {
                         Text(
-                            text = "${(tempScrobbleDelayPercent * 100).roundToInt()}%",
+                            text = stringResource(R.string.percentage_format, (tempScrobbleDelayPercent * 100).roundToInt()),
                             style = MaterialTheme.typography.bodyLarge,
                             modifier = Modifier.padding(bottom = 16.dp)
                         )
@@ -414,7 +416,7 @@ fun LastFMSettings(
                         modifier = Modifier.padding(16.dp)
                     ) {
                         Text(
-                            text = "${tempScrobbleDelaySeconds}s",
+                            text = stringResource(R.string.seconds_format, tempScrobbleDelaySeconds),
                             style = MaterialTheme.typography.bodyLarge,
                             modifier = Modifier.padding(bottom = 16.dp)
                         )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
@@ -85,11 +85,11 @@ fun LyricsAnimationSettings(
                 )
                 .padding(bottom = 16.dp)
         ) {
-            PreferenceGroup(title = "Animation Tuning") {
+            PreferenceGroup(title = stringResource(R.string.animation_tuning)) {
                 item {
                     PreferenceEntry(
-                        title = { Text("Line Bounce Effect") },
-                        description = "Enable bounce animation for line-synced (LRC) lyrics",
+                        title = { Text(stringResource(R.string.line_bounce_effect)) },
+                        description = stringResource(R.string.line_bounce_effect_desc),
                         icon = { Icon(painterResource(R.drawable.animation), null) },
                         trailingContent = {
                             Switch(
@@ -102,8 +102,8 @@ fun LyricsAnimationSettings(
 
                 item {
                     PreferenceEntry(
-                        title = { Text("Bounce Amplitude") },
-                        description = "Adjust the bounce effect when a word is sung (${(bounceFactor * 100).toInt()}%)",
+                        title = { Text(stringResource(R.string.bounce_amplitude)) },
+                        description = stringResource(R.string.bounce_amplitude_desc, (bounceFactor * 100).toInt()),
                         icon = { Icon(painterResource(R.drawable.animation), null) },
                         content = {
                             Slider(
@@ -117,8 +117,8 @@ fun LyricsAnimationSettings(
 
                 item {
                     PreferenceEntry(
-                        title = { Text("Glow Intensity") },
-                        description = "Adjust the glow brightness of the sung word (${(glowFactor * 100).toInt()}%)",
+                        title = { Text(stringResource(R.string.glow_intensity)) },
+                        description = stringResource(R.string.glow_intensity_desc, (glowFactor * 100).toInt()),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         content = {
                             Slider(
@@ -132,8 +132,8 @@ fun LyricsAnimationSettings(
 
                 item {
                     PreferenceEntry(
-                        title = { Text("Fill Transition Smoothness") },
-                        description = "Adjust the gradient edge width of the liquid fill effect (${fillTransitionWidth.toInt()} dp)",
+                        title = { Text(stringResource(R.string.fill_transition_smoothness)) },
+                        description = stringResource(R.string.fill_transition_smoothness_desc, fillTransitionWidth.toInt()),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         content = {
                             Slider(

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -472,7 +472,7 @@ fun LyricsSettings(
 
             item(visible = enablePaxsenixLyrics) {
                 SwitchPreference(
-                    title = { Text("Paxsenix: Apple Music") },
+                    title = { Text(stringResource(R.string.paxsenix_apple_music)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = enablePaxsenixAppleMusicLyrics,
                     onCheckedChange = onEnablePaxsenixAppleMusicLyricsChange,
@@ -481,7 +481,7 @@ fun LyricsSettings(
 
             item(visible = enablePaxsenixLyrics) {
                 SwitchPreference(
-                    title = { Text("Paxsenix: NetEase") },
+                    title = { Text(stringResource(R.string.paxsenix_netease)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = enablePaxsenixNeteaseLyrics,
                     onCheckedChange = onEnablePaxsenixNeteaseLyricsChange,
@@ -490,7 +490,7 @@ fun LyricsSettings(
 
             item(visible = enablePaxsenixLyrics) {
                 SwitchPreference(
-                    title = { Text("Paxsenix: Spotify") },
+                    title = { Text(stringResource(R.string.paxsenix_spotify)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = enablePaxsenixSpotifyLyrics,
                     onCheckedChange = onEnablePaxsenixSpotifyLyricsChange,
@@ -499,7 +499,7 @@ fun LyricsSettings(
 
             item(visible = enablePaxsenixLyrics) {
                 SwitchPreference(
-                    title = { Text("Paxsenix: Musixmatch") },
+                    title = { Text(stringResource(R.string.paxsenix_musixmatch)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = enablePaxsenixMusixmatchLyrics,
                     onCheckedChange = onEnablePaxsenixMusixmatchLyricsChange,
@@ -508,7 +508,7 @@ fun LyricsSettings(
 
             item(visible = enablePaxsenixLyrics) {
                 SwitchPreference(
-                    title = { Text("Paxsenix: KuGou") },
+                    title = { Text(stringResource(R.string.paxsenix_kugou)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = enablePaxsenixKuGouLyrics,
                     onCheckedChange = onEnablePaxsenixKuGouLyricsChange,
@@ -590,7 +590,7 @@ fun LyricsSettings(
                     onValueChange = onQueueLyricsPreloadCountChange,
                     minValue = 0,
                     maxValue = 10,
-                    valueText = { if (it == 0) "Off" else it.toString() },
+                    valueText = { if (it == 0) stringResource(R.string.provider_off) else it.toString() },
                 )
             }
         }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/MusicTogetherScreen.kt
@@ -274,7 +274,7 @@ fun MusicTogetherScreen(
     if (showPortDialog) {
         TextFieldDialog(
             title = { Text(text = stringResource(R.string.together_port)) },
-            placeholder = { Text(text = "42117") },
+            placeholder = { Text(text = stringResource(R.string.together_default_port)) },
             isInputValid = { it.trim().toIntOrNull() in 1..65535 },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Number,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/PalettePickerScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/PalettePickerScreen.kt
@@ -1095,7 +1095,7 @@ fun ThemeCreatorScreen(
                     onClick = {
                         val safeName = themeName
                             .trim()
-                            .ifBlank { "ArchiveTune Theme" }
+                            .ifBlank { stringResource(R.string.default_theme_name) }
                             .replace(Regex("[^a-zA-Z0-9 _\\-]"), "_")
                             .take(64)
                         exportLauncher.launch("$safeName.json")

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/SettingsComponents.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/SettingsComponents.kt
@@ -307,7 +307,7 @@ fun SettingsUpdateBanner(
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
                 Text(
-                    text = "v$latestVersion",
+                    text = stringResource(R.string.version_prefix, latestVersion),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.75f),
                     fontWeight = FontWeight.Medium,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -168,48 +168,48 @@ fun UpdateScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        text = "ArchiveTune provides two download channels for builds:",
+                        text = stringResource(R.string.update_dialog_intro),
                         style = MaterialTheme.typography.bodyMedium
                     )
 
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         Text(
-                            text = "• Stable builds",
+                            text = stringResource(R.string.stable_builds),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            text = "Distributed via official GitHub Releases.",
+                            text = stringResource(R.string.stable_builds_desc_1),
                             style = MaterialTheme.typography.bodySmall
                         )
                         Text(
-                            text = "These versions are tested and recommended for most users.",
+                            text = stringResource(R.string.stable_builds_desc_2),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
 
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         Text(
-                            text = "• Nightly builds",
+                            text = stringResource(R.string.nightly_builds),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            text = "Automatically generated development builds hosted via nightly.link.",
+                            text = stringResource(R.string.nightly_builds_desc_1),
                             style = MaterialTheme.typography.bodySmall
                         )
                         Text(
-                            text = "Nightly builds may include experimental features, unfinished changes, or temporary regressions.",
+                            text = stringResource(R.string.nightly_builds_desc_2),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
 
                     Text(
-                        text = "Nightly builds are provided for testing and early access only.\nStability, compatibility, and functionality are not guaranteed.",
+                        text = stringResource(R.string.nightly_builds_desc_3),
                         style = MaterialTheme.typography.bodySmall
                     )
                     Text(
-                        text = "By continuing, you acknowledge that nightly builds may be unstable and use them at your own risk.",
+                        text = stringResource(R.string.nightly_builds_desc_4),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
@@ -247,48 +247,48 @@ fun UpdateScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        text = "ArchiveTune provides two download channels for builds:",
+                        text = stringResource(R.string.update_dialog_intro),
                         style = MaterialTheme.typography.bodyMedium
                     )
 
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         Text(
-                            text = "• Stable builds",
+                            text = stringResource(R.string.stable_builds),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            text = "Distributed via official GitHub Releases.",
+                            text = stringResource(R.string.stable_builds_desc_1),
                             style = MaterialTheme.typography.bodySmall
                         )
                         Text(
-                            text = "These versions are tested and recommended for most users.",
+                            text = stringResource(R.string.stable_builds_desc_2),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
 
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         Text(
-                            text = "• Nightly builds",
+                            text = stringResource(R.string.nightly_builds),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            text = "Automatically generated development builds hosted via nightly.link.",
+                            text = stringResource(R.string.nightly_builds_desc_1),
                             style = MaterialTheme.typography.bodySmall
                         )
                         Text(
-                            text = "Nightly builds may include experimental features, unfinished changes, or temporary regressions.",
+                            text = stringResource(R.string.nightly_builds_desc_2),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
 
                     Text(
-                        text = "Nightly builds are provided for testing and early access only.\nStability, compatibility, and functionality are not guaranteed.",
+                        text = stringResource(R.string.nightly_builds_desc_3),
                         style = MaterialTheme.typography.bodySmall
                     )
                     Text(
-                        text = "By continuing, you acknowledge that nightly builds may be unstable and use them at your own risk.",
+                        text = stringResource(R.string.nightly_builds_desc_4),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/utils/ShowMediaInfo.kt
@@ -177,13 +177,13 @@ fun ShowMediaInfo(videoId: String) {
     }
 
     val technicalDetails = buildList {
-        currentFormat?.itag?.toString()?.let { add(MediaInfoDetail(label = "Itag", value = it)) }
+        currentFormat?.itag?.toString()?.let { add(MediaInfoDetail(label = stringResource(R.string.itag_label), value = it)) }
         currentFormat?.mimeType?.takeIf { it.isNotBlank() }
             ?.let { add(MediaInfoDetail(label = mimeTypeLabel, value = it)) }
         currentFormat?.codecs?.takeIf { it.isNotBlank() }
             ?.let { add(MediaInfoDetail(label = codecsLabel, value = it)) }
         currentFormat?.bitrate?.takeIf { it > 0 }
-            ?.let { add(MediaInfoDetail(label = bitrateLabel, value = "${it / 1000} Kbps")) }
+            ?.let { add(MediaInfoDetail(label = bitrateLabel, value = stringResource(R.string.kbps_unit, it / 1000))) }
         currentFormat?.sampleRate?.takeIf { it > 0 }
             ?.let { add(MediaInfoDetail(label = sampleRateLabel, value = "$it Hz")) }
         currentFormat?.loudnessDb?.let { add(MediaInfoDetail(label = loudnessLabel, value = "$it dB")) }
@@ -205,7 +205,7 @@ fun ShowMediaInfo(videoId: String) {
             ?.takeIf { it.isNotBlank() }
             ?.let { add(MediaInfoQuickFact(iconRes = R.drawable.graphic_eq, text = it)) }
         currentFormat?.bitrate?.takeIf { it > 0 }
-            ?.let { add(MediaInfoQuickFact(iconRes = R.drawable.waves, text = "${it / 1000} Kbps")) }
+            ?.let { add(MediaInfoQuickFact(iconRes = R.drawable.waves, text = stringResource(R.string.kbps_unit, it / 1000))) }
         currentFormat?.contentLength?.takeIf { it > 0 }
             ?.let {
                 add(

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -441,4 +441,340 @@
     <string name="ai_api_test_failed">APIテストに失敗しました</string>
     <string name="ai_translation_menu">AI翻訳</string>
     <string name="ai_translating_lyrics">歌詞を翻訳中...</string>
+
+    <!-- AOD customization -->
+    <string name="aod_customize_title">AODカスタマイズ</string>
+    <string name="aod_customize_subtitle">形状、レイアウト、コントロール、アンビエントスタイル</string>
+    <string name="aod_customize_entry_desc">常時表示プレイヤー画面をカスタマイズ</string>
+    <string name="aod_customize_preview">ライブプレビュー</string>
+    <string name="aod_customize_visibility">表示設定</string>
+    <string name="aod_customize_show_thumbnail">サムネイルを表示</string>
+    <string name="aod_customize_show_artist">アーティスト名を表示</string>
+    <string name="aod_customize_show_album">アルバム名を表示</string>
+    <string name="aod_customize_show_progress">再生バーを表示</string>
+    <string name="aod_customize_show_time_labels">時間ラベルを表示</string>
+    <string name="aod_customize_show_controls">コントロールを表示</string>
+    <string name="aod_customize_show_exit_button">終了ボタンを表示</string>
+    <string name="aod_customize_thumbnail_shape">サムネイル形状</string>
+    <string name="aod_customize_thumbnail_shape_desc">AODアートワークのマスク形状を設定します。</string>
+    <string name="aod_customize_layout">レイアウト</string>
+    <string name="aod_customize_background_style">背景スタイル</string>
+    <string name="aod_customize_accent_style">アクセントスタイル</string>
+    <string name="aod_customize_content_position">コンテンツ位置</string>
+    <string name="aod_customize_text_alignment">テキスト配置</string>
+    <string name="aod_customize_title_max_lines">タイトルの最大行数</string>
+    <string name="aod_customize_scale_and_spacing">拡大率と間隔</string>
+    <string name="aod_customize_thumbnail_size">サムネイルサイズ</string>
+    <string name="aod_customize_shape_rotation">シェイプ回転</string>
+    <string name="aod_customize_horizontal_padding">水平パディング</string>
+    <string name="aod_customize_vertical_spacing">垂直間隔</string>
+    <string name="aod_customize_ambient_intensity">アンビエント強度</string>
+    <string name="aod_customize_artwork_glow">アートワークの発光</string>
+    <string name="aod_customize_controls">コントロール</string>
+    <string name="aod_customize_control_style">コントロールスタイル</string>
+    <string name="aod_customize_control_size">コントロールサイズ</string>
+    <string name="aod_customize_dp_value">%1$d dp</string>
+    <string name="aod_customize_degree_value">%1$d°</string>
+    <string name="aod_customize_percent_value">%1$d%%</string>
+    <string name="aod_customize_sample_title">Midnight Archive</string>
+    <string name="aod_customize_sample_artist">Koiverse Ensemble</string>
+    <string name="aod_customize_sample_album">Always On Sessions</string>
+    <string name="aod_customize_sample_elapsed">1:24</string>
+    <string name="aod_customize_sample_duration">3:48</string>
+    <string name="aod_shape_rounded">角丸</string>
+    <string name="aod_shape_square">四角</string>
+    <string name="aod_shape_circle">丸</string>
+    <string name="aod_shape_pill">ピル型</string>
+    <string name="aod_shape_arch">アーチ</string>
+    <string name="aod_shape_slanted">斜め</string>
+    <string name="aod_shape_diamond">ダイヤモンド</string>
+    <string name="aod_shape_pentagon">五角形</string>
+    <string name="aod_shape_triangle">三角形</string>
+    <string name="aod_shape_heart">ハート</string>
+    <string name="aod_shape_flower">花</string>
+    <string name="aod_shape_clover_4">クローバー</string>
+    <string name="aod_shape_cookie_6">クッキー6</string>
+    <string name="aod_shape_cookie_9">クッキー9</string>
+    <string name="aod_shape_sunny">サニー</string>
+    <string name="aod_shape_soft_burst">ソフトバースト</string>
+    <string name="aod_shape_ghostish">ゴースト</string>
+    <string name="aod_shape_pixel_circle">ピクセルサークル</string>
+    <string name="aod_background_pure_black">ピュアブラック</string>
+    <string name="aod_background_soft_radial">ソフトラジアル</string>
+    <string name="aod_background_tonal_edge">トーンのエッジ</string>
+    <string name="aod_background_ambient_glow">アンビエントグロー</string>
+    <string name="aod_accent_monochrome">モノクロ</string>
+    <string name="aod_accent_theme">テーマ</string>
+    <string name="aod_position_top">上</string>
+    <string name="aod_position_center">中央</string>
+    <string name="aod_position_bottom">下</string>
+    <string name="aod_alignment_start">左揃え</string>
+    <string name="aod_alignment_center">中央揃え</string>
+    <string name="aod_alignment_end">右揃え</string>
+    <string name="aod_control_filled">塗りつぶし</string>
+    <string name="aod_control_tonal">トーン</string>
+    <string name="aod_control_minimal">ミニマル</string>
+
+    <string name="playlist_sync_progress_step">%1$d/%2$d 曲</string>
+    <string name="playlist_sync_failed">プレイリスト同期エラー: %1$s</string>
+    <string name="mini_player_background_style">ミニプレイヤーの背景スタイル</string>
+    <string name="player_design_v8">イマーシブエクステンデッド</string>
+    <string name="player_design_v9">マテリアルエクステンデッド</string>
+    <string name="restart">再起動</string>
+    <string name="android_auto_suggested_songs">おすすめの曲</string>
+    <string name="android_auto_mixes_and_radios">ミックスとラジオ</string>
+    <string name="android_auto_sort_playlist">プレイリストを並べ替え</string>
+    <string name="android_auto_sort_option_format">%1$s - %2$s</string>
+
+    <!-- Backup & Restore -->
+    <string name="internal_service">内部サービス</string>
+    <string name="external_service">外部サービス</string>
+    <string name="backup_data_safety">データの安全性</string>
+    <string name="backup_data_safety_desc">ポータブルバックアップを作成するか、選択したアプリデータを復元します。</string>
+    <string name="backup_data_formats">.backup アーカイブ</string>
+    <string name="backup_create_backup_desc">ライブラリ、設定、アカウント情報をエクスポートします。</string>
+    <string name="backup_restore_backup_desc">以前のバックアップから選択したデータを復元します。</string>
+    <string name="import_from_file">ファイルからインポート</string>
+    <string name="import_from_file_desc">ローカルのM3UまたはCSVファイルからプレイリストを取り込みます。</string>
+    <string name="import_m3u_format">M3Uオーディオプレイリスト</string>
+    <string name="import_csv_format">CSVプレイリストファイル</string>
+
+    <!-- Spotify -->
+    <string name="spotify_connect">Spotifyに接続</string>
+    <string name="spotify_refresh">Spotifyライブラリを更新</string>
+    <string name="spotify_available_count">%1$d 個のプレイリストが利用可能</string>
+    <string name="spotify_connected_as">%1$s として接続中</string>
+    <string name="spotify_not_connected">Spotifyが接続されていません</string>
+    <string name="spotify_track_count">%1$d 曲</string>
+    <string name="spotify_login_title">Spotifyログイン</string>
+    <string name="spotify_loading_library">Spotifyライブラリを読み込み中</string>
+    <string name="spotify_no_sources">Spotifyのプレイリストが見つかりません</string>
+    <string name="spotify_account">Spotifyアカウント</string>
+    <string name="spotify_playlists">Spotifyプレイリスト</string>
+    <string name="spotify_waiting_for_login">Spotifyのログインを待機中</string>
+    <string name="spotify_show_playlist">プレイリストを表示</string>
+    <string name="spotify_show_playlist_desc">Spotifyのプレイリストをライブラリに表示します。</string>
+    <string name="spotify_reload_playlist">プレイリストを再読み込み</string>
+    <string name="spotify_reload_playlist_desc">Spotifyのプレイリストをアカウントから更新します。</string>
+    <string name="spotify_no_tracks">Spotifyの曲が見つかりませんでした。</string>
+
+    <!-- DebugActivity -->
+    <string name="share_logs">ログを共有</string>
+    <string name="crash_report">クラッシュレポート</string>
+    <string name="application_crashed">アプリケーションがクラッシュしました</string>
+    <string name="device_info">デバイス情報</string>
+    <string name="stack_trace">スタックトレース</string>
+
+    <!-- PlayerComponents -->
+    <string name="copied_title">タイトルをコピーしました</string>
+    <string name="copied_artist">アーティスト名をコピーしました</string>
+    <string name="blurred_background">ぼかし背景</string>
+    <string name="custom_background">カスタム背景</string>
+    <string name="codec_lossless">ロスレス</string>
+    <string name="codec_aac">AAC</string>
+    <string name="codec_vorbis">Vorbis</string>
+    <string name="codec_opus">OPUS</string>
+
+    <!-- LyricsAnimationSettings -->
+    <string name="animation_tuning">アニメーション調整</string>
+    <string name="line_bounce_effect">ラインバウンス効果</string>
+    <string name="line_bounce_effect_desc">ライン同期（LRC）歌詞のバウンスアニメーションを有効にします</string>
+    <string name="bounce_amplitude">バウンス振幅</string>
+    <string name="bounce_amplitude_desc">歌詞が歌われるときのバウンス効果を調整します（%d%%）</string>
+    <string name="glow_intensity">グロー強度</string>
+    <string name="glow_intensity_desc">歌詞のグローの明るさを調整します（%d%%）</string>
+    <string name="fill_transition_smoothness">塗りつぶしの遷移滑らかさ</string>
+    <string name="fill_transition_smoothness_desc">液体充填効果のグラデーションエッジ幅を調整します（%d dp）</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_dialog_intro">ArchiveTuneでは、ビルド用に2つのダウンロードチャンネルを提供しています：</string>
+    <string name="stable_builds">• 安定版ビルド</string>
+    <string name="stable_builds_desc_1">公式のGitHubリリースを通じて配布されます。</string>
+    <string name="stable_builds_desc_2">これらのバージョンはテスト済みで、ほとんどのユーザーにおすすめです。</string>
+    <string name="nightly_builds">• ナイトリービルド</string>
+    <string name="nightly_builds_desc_1">nightly.linkを通じて自動生成される開発ビルドです。</string>
+    <string name="nightly_builds_desc_2">ナイトリービルドには実験的な機能、未完成の変更、一時的な不具合が含まれる場合があります。</string>
+    <string name="nightly_builds_desc_3">ナイトリービルドはテストおよび早期アクセス専用に提供されます。\n安定性、互換性、機能性は保証されません。</string>
+    <string name="nightly_builds_desc_4">続行することで、ナイトリービルドが不安定である可能性があることを了承し、自己責任で使用することに同意します。</string>
+
+    <!-- Lyrics provider names -->
+    <string name="paxsenix_apple_music">Paxsenix: Apple Music</string>
+    <string name="paxsenix_netease">Paxsenix: NetEase</string>
+    <string name="paxsenix_spotify">Paxsenix: Spotify</string>
+    <string name="paxsenix_musixmatch">Paxsenix: Musixmatch</string>
+    <string name="paxsenix_kugou">Paxsenix: KuGou</string>
+    <string name="provider_off">オフ</string>
+    <string name="provider_lrclib">LrcLib</string>
+    <string name="provider_kugou">KuGou</string>
+    <string name="provider_better_lyrics">BetterLyrics</string>
+    <string name="provider_simpmusic">SimpMusic</string>
+    <string name="provider_unison">Unison</string>
+
+    <!-- AboutScreen -->
+    <string name="about_debug">デバッグ</string>
+    <string name="about_koiverse">Koiverse</string>
+    <string name="about_lead_developer">リードデベロッパー</string>
+    <string name="about_collaborators">コラボレーター</string>
+    <string name="about_contributors">コントリビューター</string>
+
+    <!-- DiscordSettings -->
+    <string name="discord_listen_on_yt_music">YouTube Musicで聴く</string>
+    <string name="discord_go_to_archivetune">ArchiveTuneを開く</string>
+    <string name="edit_dialog_title">%1$s を編集</string>
+    <string name="bullet_item">• %1$s</string>
+    <string name="selection_queue_title">選択中</string>
+    <string name="unknown_error">不明なエラー</string>
+    <string name="version_prefix">v%1$s</string>
+    <string name="together_default_port">42117</string>
+    <string name="tempo_pitch_display">x%1$.2f • x%2$.2f</string>
+    <string name="volume_percentage">%1$d%%</string>
+    <string name="tempo_multiplier">x%1$.2f</string>
+    <string name="pitch_multiplier">x%1$.2f</string>
+    <string name="semitone_value">%1$+d</string>
+    <string name="playback_error_decoder">%1$s（コード %2$d）</string>
+    <string name="playback_error_http">%1$s（HTTP %2$d）</string>
+    <string name="lastfm_api_key_not_configured">Last.fm APIキーが設定されていません</string>
+    <string name="seconds_format">%1$d秒</string>
+    <string name="version_display">v%1$s（%2$d）</string>
+    <string name="no_playlists_yet">プレイリストがまだありません</string>
+    <string name="add_to_n">%1$dに追加</string>
+    <string name="add_to_playlist_short">追加</string>
+    <string name="no_stack_trace">利用可能なスタックトレースはありません</string>
+    <string name="share_crash_log">クラッシュログを共有</string>
+    <string name="time_am">午前</string>
+    <string name="time_pm">午後</string>
+    <string name="suggestions_available">おすすめがあります</string>
+    <string name="crash_report_header">ArchiveTune クラッシュレポート</string>
+    <string name="crash_report_time">日時: %1$s</string>
+    <string name="crash_report_app">アプリ: %1$s</string>
+    <string name="crash_report_package">パッケージ: %1$s</string>
+    <string name="crash_report_device_section">デバイス</string>
+    <string name="crash_report_stack_trace_section">スタックトレース</string>
+    <string name="device_os_version">OSバージョン</string>
+    <string name="device_phone_name">端末名</string>
+    <string name="device_model">モデル</string>
+    <string name="device_manufacturer">メーカー</string>
+    <string name="device_brand">ブランド</string>
+    <string name="device_device">デバイス</string>
+    <string name="device_product">製品</string>
+    <string name="device_hardware">ハードウェア</string>
+    <string name="device_fingerprint">フィンガープリント</string>
+    <string name="device_os_version_value">Android %1$s（SDK %2$d）</string>
+
+    <!-- AddToPlaylistDialogOnline -->
+    <string name="import_complete">インポート完了</string>
+    <string name="total_processed">処理合計: %1$d</string>
+    <string name="successfully_imported">正常にインポート: %1$d</string>
+    <string name="failed_imports">失敗: %1$d</string>
+    <string name="failed_items_section">失敗した項目:</string>
+
+    <!-- AddToPlaylistDialog -->
+    <string name="add_to_playlist">プレイリストに追加</string>
+    <string name="n_d_selected">%1$d 個選択済み</string>
+
+    <!-- NetworkStatusBanner -->
+    <string name="no_internet_connection">インターネット接続がありません</string>
+    <string name="back_online">オンラインに戻りました</string>
+
+    <!-- LyricsV2 -->
+    <string name="resume_lyrics">再開</string>
+
+    <!-- SearchBar -->
+    <string name="search_cd">検索</string>
+
+    <!-- ThumbnailCornerRadiusSelector -->
+    <string name="dp_unit">dp</string>
+    <string name="min_radius">0</string>
+    <string name="max_radius">45</string>
+
+    <!-- NewReleaseScreen -->
+    <string name="new_releases_unavailable">新着リリースは一時的に利用できません</string>
+    <string name="new_releases_unavailable_desc">ArchiveTuneがこのYouTube Musicセクションを読み込めませんでした。後でもう一度お試しください。</string>
+
+    <!-- StatsScreen -->
+    <string name="time_12am">午前0時</string>
+    <string name="time_6am">午前6時</string>
+    <string name="time_12pm">正午</string>
+    <string name="time_6pm">午後6時</string>
+
+    <!-- Start Mix -->
+    <string name="start_mix_cd">ミックスを開始</string>
+
+    <!-- CachePlaylistScreen -->
+    <string name="cache_songs_title">曲をキャッシュ</string>
+
+    <!-- ShowMediaInfo -->
+    <string name="itag_label">Itag</string>
+    <string name="kbps_unit">%1$d Kbps</string>
+
+    <!-- App.kt -->
+    <string name="failed_to_parse_proxy">プロキシ設定の解析に失敗しました。</string>
+
+    <!-- Player.kt -->
+    <string name="by_prefix">by - %1$s</string>
+
+    <!-- Queue.kt -->
+    <string name="speaker_default">スピーカー</string>
+
+    <!-- LastFMSettings -->
+    <string name="login_enter_credentials">ユーザー名とパスワードを入力してください</string>
+    <string name="login_invalid_credentials">ユーザー名またはパスワードが無効です</string>
+    <string name="login_invalid_api_key">無効なAPIキーです。開発者にお問い合わせください。</string>
+    <string name="login_auth_error">認証エラーです。もう一度お試しください。</string>
+    <string name="login_api_key_suspended">APIキーが停止されました。開発者にお問い合わせください。</string>
+    <string name="login_network_error">ネットワークエラーです。接続を確認してください。</string>
+    <string name="login_failed_generic">ログインに失敗しました。もう一度お試しください。</string>
+
+    <!-- AppearanceSettings -->
+    <string name="glow_animated">アニメーショングロー</string>
+
+    <!-- AccountSettings -->
+    <string name="integration_subtitle">Discord、Last.fm、ListenBrainz</string>
+
+    <!-- PalettePickerScreen -->
+    <string name="default_theme_name">ArchiveTune テーマ</string>
+
+    <!-- LocalMixQueue -->
+    <string name="mix_from_playlist">プレイリストからミックス</string>
+
+    <!-- LyricsMenu -->
+    <string name="synced_badge">同期済み</string>
+
+    <!-- ArtistSeparatorsDialog -->
+    <string name="separator_display">「%1$s」</string>
+
+    <!-- AboutScreen content descriptions -->
+    <string name="about_github">GitHub</string>
+    <string name="about_website">ウェブサイト</string>
+    <string name="about_discord">Discord</string>
+
+    <!-- Stats / Year in Music -->
+    <string name="top_songs">トップ曲</string>
+    <string name="year_in_music_recap">音楽まとめ</string>
+    <string name="year_in_music_recap_word">まとめ</string>
+    <string name="year_in_music_intro_title">今年をもう一度</string>
+    <string name="year_in_music_intro_subtitle">%d年のあなたを形作った曲、アーティスト、アルバムのまとめです。</string>
+    <string name="year_in_music_intro_hero">お待たせしました！あなたの年間音楽まとめ</string>
+    <string name="year_in_music_intro_details">トップ曲、アーティスト、アルバム、再生時間を表示します。</string>
+    <string name="year_in_music_swipe_begin">スワイプして開始</string>
+    <string name="year_in_music_totals_title">音楽とともに過ごした日々</string>
+    <string name="year_in_music_top_track">あなたのトップ曲</string>
+    <string name="year_in_music_ranked_artists">よく聴いたアーティスト</string>
+    <string name="year_in_music_ranked_albums">何度も聴いたアルバム</string>
+    <string name="year_in_music_final_title">これがあなたの一年でした</string>
+    <string name="year_in_music_musical_passport">私の音楽パスポート</string>
+    <string name="year_in_music_empty_title">まだまとめるデータがありません</string>
+    <string name="year_in_music_empty_subtitle">%d年にもっと音楽を聴くと、まとめがここに表示されます。</string>
+    <string name="year_in_music_minutes_label">再生時間</string>
+    <string name="year_in_music_minutes_unit">分</string>
+    <string name="year_in_music_plays_label">総再生数</string>
+    <string name="year_in_music_top_pick">トップピック</string>
+    <string name="year_in_music_current_card">カードを共有</string>
+
+    <!-- Local songs scan folders -->
+    <string name="local_songs_scan_included_folders_title">含めるフォルダー</string>
+    <string name="local_songs_scan_included_folders_desc">これらのパスのいずれかに一致するフォルダーに保存されている曲のみをスキャンします。</string>
+    <string name="local_songs_scan_included_folders_empty">すべてのフォルダーが含まれています。</string>
+    <string name="local_songs_scan_included_folders_add">フォルダーを含める</string>
+
 </resources>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -365,4 +365,452 @@
     <string name="backup_category_account">Chi tiết tài khoản</string>
     <string name="backup_category_account_desc">Thông tin đăng nhập YouTube, Last.fm, Discord và proxy</string>
     <string name="login_success">Đăng nhập thành công</string>
+
+    <!-- New releases -->
+    <string name="new_releases">Bản phát hành mới</string>
+    <string name="total_releases">Tổng số bản phát hành</string>
+    <string name="singles">Đĩa đơn</string>
+    <string name="ep">EP</string>
+    <string name="no_releases_found">Không tìm thấy bản phát hành nào</string>
+
+    <!-- Android Auto -->
+    <string name="android_auto_suggested_songs">Bài hát gợi ý</string>
+    <string name="android_auto_mixes_and_radios">Tổng hợp và radio</string>
+    <string name="android_auto_sort_playlist">Sắp xếp danh sách phát</string>
+    <string name="android_auto_sort_option_format">%1$s - %2$s</string>
+
+    <!-- Monthly listeners -->
+    <string name="monthly_listeners">Người nghe hàng tháng</string>
+
+    <!-- Playlist sync -->
+    <string name="playlist_sync_progress_step">%1$d/%2$d bài hát</string>
+    <string name="playlist_sync_failed">Đồng bộ danh sách phát thất bại: %1$s</string>
+
+    <!-- Player designs -->
+    <string name="player_design_v8">Mở rộng đắm chìm</string>
+    <string name="player_design_v9">Mở rộng Material</string>
+    <string name="mini_player_background_style">Kiểu nền trình phát mini</string>
+
+    <!-- Force sync -->
+    <string name="force_sync_on_switch_account">Buộc đồng bộ khi chuyển tài khoản</string>
+    <string name="force_sync_on_switch_account_desc">Đồng bộ lại danh sách phát, bài hát đã thích, nghệ sĩ và album từ tài khoản đã chọn sau khi chuyển</string>
+
+    <!-- Top songs -->
+    <string name="top_songs">Bài hát hàng đầu</string>
+
+    <!-- Settings section titles and subtitles -->
+    <string name="settings_appearance_subtitle">Giao diện, bố cục và kiểu hình ảnh</string>
+    <string name="settings_playback_title">Phát lại</string>
+    <string name="settings_playback_subtitle">Hành vi âm thanh, chuyển bài và phát nền</string>
+    <string name="settings_behavior_title">Hành vi</string>
+    <string name="settings_behavior_subtitle">Lịch sử, mặc định và hành vi riêng tư</string>
+    <string name="settings_integration_subtitle">Discord, Last.fm và ListenBrainz</string>
+    <string name="settings_backup_restore_subtitle">Xuất và khôi phục dữ liệu ứng dụng cá nhân</string>
+    <string name="settings_developer_options_title">Tùy chọn nhà phát triển</string>
+    <string name="settings_developer_options_subtitle">Tính năng thử nghiệm và gỡ lỗi</string>
+    <string name="settings_lyrics_subtitle">Nhà cung cấp lời bài hát, tải trước và dịch thuật</string>
+    <string name="settings_content_subtitle">Mặc định ngôn ngữ, quốc gia và đề xuất</string>
+    <string name="settings_internet_subtitle">Proxy, DNS và hành vi phát mạng</string>
+    <string name="settings_po_token_subtitle">Xác minh phát lại và dữ liệu khách</string>
+    <string name="settings_storage_subtitle">Cache, tải xuống và lưu trữ ngoại tuyến</string>
+    <string name="settings_updates_subtitle">Phiên bản, ghi chú phát hành và kênh cập nhật</string>
+    <string name="settings_about_subtitle">Thông tin ứng dụng, giấy phép và người đóng góp</string>
+    <string name="settings_account_subtitle">Đăng nhập và quản lý đồng bộ tài khoản</string>
+    <string name="settings_stats_title">Thống kê nghe nhạc</string>
+    <string name="settings_stats_subtitle">Bài hát, nghệ sĩ hàng đầu và lịch sử phát của bạn</string>
+
+    <!-- Year in Music -->
+    <string name="year_in_music_recap">Tổng kết âm nhạc</string>
+    <string name="year_in_music_recap_word">TỔNG KẾT</string>
+    <string name="year_in_music_intro_title">Phát lại năm của bạn</string>
+    <string name="year_in_music_intro_subtitle">Bản tổng kết các bài hát, nghệ sĩ và album đã định hình %d.</string>
+    <string name="year_in_music_intro_hero">Đã đến! Năm trong âm nhạc của bạn.</string>
+    <string name="year_in_music_intro_details">Khám phá bài hát, nghệ sĩ, album và thời gian nghe hàng đầu của bạn.</string>
+    <string name="year_in_music_swipe_begin">Vuốt để bắt đầu</string>
+    <string name="year_in_music_totals_title">Bạn đã giữ cho âm nhạc luôn chuyển động</string>
+    <string name="year_in_music_top_track">Bài hát hàng đầu của bạn</string>
+    <string name="year_in_music_ranked_artists">Nghệ sĩ phát nhiều nhất</string>
+    <string name="year_in_music_ranked_albums">Album bạn đã quay lại</string>
+    <string name="year_in_music_final_title">Đó là năm của bạn</string>
+    <string name="year_in_music_musical_passport">Hộ chiếu âm nhạc của tôi</string>
+    <string name="year_in_music_empty_title">Chưa có gì để tổng kết</string>
+    <string name="year_in_music_empty_subtitle">Nghe nhiều nhạc hơn trong %d và bản tổng kết của bạn sẽ xuất hiện tại đây.</string>
+    <string name="year_in_music_minutes_label">Thời gian nghe</string>
+    <string name="year_in_music_minutes_unit">phút</string>
+    <string name="year_in_music_plays_label">Tổng lượt phát</string>
+    <string name="year_in_music_top_pick">Lựa chọn hàng đầu</string>
+    <string name="year_in_music_current_card">Chia sẻ thẻ</string>
+
+    <!-- New releases screen -->
+    <string name="new_releases_unavailable">Bản phát hành mới tạm thời không khả dụng</string>
+    <string name="new_releases_unavailable_desc">ArchiveTune không thể tải mục YouTube Music này. Thử lại sau.</string>
+
+    <!-- Local songs included folders -->
+    <string name="local_songs_scan_included_folders_title">Thư mục bao gồm</string>
+    <string name="local_songs_scan_included_folders_desc">Chỉ quét các bài hát trong thư mục khớp với bất kỳ đường dẫn nào sau đây.</string>
+    <string name="local_songs_scan_included_folders_empty">Tất cả thư mục đều được bao gồm.</string>
+    <string name="local_songs_scan_included_folders_add">Bao gồm thư mục</string>
+
+    <!-- AOD customization -->
+    <string name="aod_customize_title">Tùy chỉnh AOD</string>
+    <string name="aod_customize_subtitle">Hình dạng, bố cục, điều khiển và kiểu xung quanh</string>
+    <string name="aod_customize_entry_desc">Tùy chỉnh màn hình trình phát luôn bật</string>
+    <string name="aod_customize_preview">Xem trước trực tiếp</string>
+    <string name="aod_customize_visibility">Hiển thị</string>
+    <string name="aod_customize_show_thumbnail">Hiển thị hình nhỏ</string>
+    <string name="aod_customize_show_artist">Hiển thị nghệ sĩ</string>
+    <string name="aod_customize_show_album">Hiển thị album</string>
+    <string name="aod_customize_show_progress">Hiển thị tiến trình</string>
+    <string name="aod_customize_show_time_labels">Hiển thị nhãn thời gian</string>
+    <string name="aod_customize_show_controls">Hiển thị điều khiển</string>
+    <string name="aod_customize_show_exit_button">Hiển thị nút thoát</string>
+    <string name="aod_customize_thumbnail_shape">Hình dạng thumbnail</string>
+    <string name="aod_customize_thumbnail_shape_desc">Sử dụng hình dạng cho mặt nạ artwork AOD.</string>
+    <string name="aod_customize_layout">Bố cục</string>
+    <string name="aod_customize_background_style">Kiểu nền</string>
+    <string name="aod_customize_accent_style">Kiểu điểm nhấn</string>
+    <string name="aod_customize_content_position">Vị trí nội dung</string>
+    <string name="aod_customize_text_alignment">Căn chỉnh văn bản</string>
+    <string name="aod_customize_title_max_lines">Số dòng tối đa tiêu đề</string>
+    <string name="aod_customize_scale_and_spacing">Tỷ lệ và khoảng cách</string>
+    <string name="aod_customize_thumbnail_size">Kích thước thumbnail</string>
+    <string name="aod_customize_shape_rotation">Xoay hình dạng</string>
+    <string name="aod_customize_horizontal_padding">Đệm ngang</string>
+    <string name="aod_customize_vertical_spacing">Khoảng cách dọc</string>
+    <string name="aod_customize_ambient_intensity">Cường độ xung quanh</string>
+    <string name="aod_customize_artwork_glow">Phát sáng artwork</string>
+    <string name="aod_customize_controls">Điều khiển</string>
+    <string name="aod_customize_control_style">Kiểu điều khiển</string>
+    <string name="aod_customize_control_size">Kích thước điều khiển</string>
+    <string name="aod_customize_dp_value">%1$d dp</string>
+    <string name="aod_customize_degree_value">%1$d°</string>
+    <string name="aod_customize_percent_value">%1$d%%</string>
+    <string name="aod_customize_sample_title">Midnight Archive</string>
+    <string name="aod_customize_sample_artist">Koiverse Ensemble</string>
+    <string name="aod_customize_sample_album">Always On Sessions</string>
+    <string name="aod_customize_sample_elapsed">1:24</string>
+    <string name="aod_customize_sample_duration">3:48</string>
+
+    <!-- AOD shapes -->
+    <string name="aod_shape_rounded">Bo tròn</string>
+    <string name="aod_shape_square">Vuông</string>
+    <string name="aod_shape_circle">Hình tròn</string>
+    <string name="aod_shape_pill">Viên thuốc</string>
+    <string name="aod_shape_arch">Vòm</string>
+    <string name="aod_shape_slanted">Xiên</string>
+    <string name="aod_shape_diamond">Kim cương</string>
+    <string name="aod_shape_pentagon">Ngũ giác</string>
+    <string name="aod_shape_triangle">Tam giác</string>
+    <string name="aod_shape_heart">Trái tim</string>
+    <string name="aod_shape_flower">Hoa</string>
+    <string name="aod_shape_clover_4">Cỏ ba lá</string>
+    <string name="aod_shape_cookie_6">Cookie 6</string>
+    <string name="aod_shape_cookie_9">Cookie 9</string>
+    <string name="aod_shape_sunny">Nắng</string>
+    <string name="aod_shape_soft_burst">Bùng nổ mềm</string>
+    <string name="aod_shape_ghostish">Ma mị</string>
+    <string name="aod_shape_pixel_circle">Pixel tròn</string>
+
+    <!-- AOD backgrounds -->
+    <string name="aod_background_pure_black">Đen thuần</string>
+    <string name="aod_background_soft_radial">Tỏa tròn mềm</string>
+    <string name="aod_background_tonal_edge">Viền tông màu</string>
+    <string name="aod_background_ambient_glow">Phát sáng xung quanh</string>
+
+    <!-- AOD accents -->
+    <string name="aod_accent_monochrome">Đơn sắc</string>
+    <string name="aod_accent_theme">Giao diện</string>
+
+    <!-- AOD positions -->
+    <string name="aod_position_top">Trên</string>
+    <string name="aod_position_center">Giữa</string>
+    <string name="aod_position_bottom">Dưới</string>
+
+    <!-- AOD alignments -->
+    <string name="aod_alignment_start">Đầu</string>
+    <string name="aod_alignment_center">Giữa</string>
+    <string name="aod_alignment_end">Cuối</string>
+
+    <!-- AOD controls -->
+    <string name="aod_control_filled">Đặc</string>
+    <string name="aod_control_tonal">Tông màu</string>
+    <string name="aod_control_minimal">Tối giản</string>
+
+    <!-- AI Integration -->
+    <string name="ai_integration">Tích hợp AI</string>
+    <string name="ai_integration_desc">Cấu hình dịch thuật AI và tự động hóa cá nhân hóa.</string>
+    <string name="ai_provider_settings">Nhà cung cấp</string>
+    <string name="ai_provider">Nhà cung cấp AI</string>
+    <string name="ai_provider_desc">Chọn dịch vụ AI.</string>
+    <string name="ai_provider_none">Không (Đã tắt)</string>
+    <string name="ai_custom_endpoint">Endpoint tùy chỉnh</string>
+    <string name="ai_api_key">Khóa API</string>
+    <string name="ai_api_key_missing">Cần có khóa API để sử dụng tính năng AI.</string>
+    <string name="ai_api_key_configured">Đã cấu hình</string>
+    <string name="ai_test_api">Kiểm tra API</string>
+    <string name="ai_api_testing">Đang kiểm tra kết nối…</string>
+    <string name="ai_api_status_unknown">Chưa kiểm tra</string>
+    <string name="ai_api_status_success">API sẵn sàng</string>
+    <string name="ai_api_status_failed">API thất bại. Kiểm tra lại sau khi cập nhật cài đặt.</string>
+    <string name="ai_model">Mô hình</string>
+    <string name="ai_model_fetch_hint">Chạm làm mới để tải danh sách mô hình</string>
+    <string name="ai_model_api_key_required">Cần khóa API để tải mô hình</string>
+    <string name="ai_model_not_selected">Chưa chọn</string>
+    <string name="ai_model_loading">Đang lấy danh sách mô hình…</string>
+    <string name="ai_model_fetch_failed">Không thể lấy danh sách mô hình</string>
+    <string name="ai_fetch_models">Lấy danh sách mô hình</string>
+    <string name="ai_model_search">Tìm kiếm mô hình</string>
+    <string name="ai_model_no_results">Không có mô hình nào phù hợp</string>
+    <string name="ai_translation">Dịch AI</string>
+    <string name="ai_translation_target">Ngôn ngữ đích</string>
+    <string name="ai_api_connected">API đã kết nối</string>
+    <string name="ai_api_test_failed">Kiểm tra API thất bại</string>
+    <string name="ai_translation_menu">Dịch AI</string>
+    <string name="ai_translating_lyrics">Đang dịch lời bài hát…</string>
+
+    <!-- DebugActivity -->
+    <string name="share_logs">Chia sẻ nhật ký</string>
+    <string name="crash_report">Báo cáo sự cố</string>
+    <string name="application_crashed">Ứng dụng bị treo</string>
+    <string name="device_info">Thông tin thiết bị</string>
+    <string name="stack_trace">Stack trace</string>
+
+    <!-- PlayerComponents -->
+    <string name="copied_title">Đã sao chép tiêu đề</string>
+    <string name="copied_artist">Đã sao chép nghệ sĩ</string>
+    <string name="blurred_background">Nền mờ</string>
+    <string name="custom_background">Nền tùy chỉnh</string>
+    <string name="codec_lossless">Lossless</string>
+    <string name="codec_aac">AAC</string>
+    <string name="codec_vorbis">Vorbis</string>
+    <string name="codec_opus">OPUS</string>
+
+    <!-- LyricsAnimationSettings -->
+    <string name="animation_tuning">Tinh chỉnh hoạt ảnh</string>
+    <string name="line_bounce_effect">Hiệu ứng nảy dòng</string>
+    <string name="line_bounce_effect_desc">Bật hoạt ảnh nảy cho lời bài hát đồng bộ dòng (LRC)</string>
+    <string name="bounce_amplitude">Biên độ nảy</string>
+    <string name="bounce_amplitude_desc">Điều chỉnh hiệu ứng nảy khi một từ được hát (%d%%)</string>
+    <string name="glow_intensity">Cường độ phát sáng</string>
+    <string name="glow_intensity_desc">Điều chỉnh độ sáng phát sáng của từ đang hát (%d%%)</string>
+    <string name="fill_transition_smoothness">Độ mượt chuyển đổ đầy</string>
+    <string name="fill_transition_smoothness_desc">Điều chỉnh độ rộng cạnh gradient của hiệu ứng đổ đầy dạng lỏng (%d dp)</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_dialog_intro">ArchiveTune cung cấp hai kênh tải xuống cho các bản dựng:</string>
+    <string name="stable_builds">• Bản dựng ổn định</string>
+    <string name="stable_builds_desc_1">Được phân phối qua GitHub Releases chính thức.</string>
+    <string name="stable_builds_desc_2">Các phiên bản này đã được kiểm tra và được khuyến nghị cho hầu hết người dùng.</string>
+    <string name="nightly_builds">• Bản dựng hàng đêm</string>
+    <string name="nightly_builds_desc_1">Các bản dựng phát triển được tạo tự động lưu trữ qua nightly.link.</string>
+    <string name="nightly_builds_desc_2">Bản dựng hàng đêm có thể bao gồm tính năng thử nghiệm, thay đổi chưa hoàn thiện hoặc lỗi tạm thời.</string>
+    <string name="nightly_builds_desc_3">Bản dựng hàng đêm chỉ dành cho mục đích thử nghiệm và truy cập sớm.\nKhông đảm bảo tính ổn định, tương thích và chức năng.</string>
+    <string name="nightly_builds_desc_4">Khi tiếp tục, bạn xác nhận rằng bản dựng hàng đêm có thể không ổn định và tự chịu rủi ro khi sử dụng.</string>
+
+    <!-- Lyrics provider names -->
+    <string name="paxsenix_apple_music">Paxsenix: Apple Music</string>
+    <string name="paxsenix_netease">Paxsenix: NetEase</string>
+    <string name="paxsenix_spotify">Paxsenix: Spotify</string>
+    <string name="paxsenix_musixmatch">Paxsenix: Musixmatch</string>
+    <string name="paxsenix_kugou">Paxsenix: KuGou</string>
+    <string name="provider_off">Tắt</string>
+    <string name="provider_lrclib">LrcLib</string>
+    <string name="provider_kugou">KuGou</string>
+    <string name="provider_better_lyrics">BetterLyrics</string>
+    <string name="provider_simpmusic">SimpMusic</string>
+    <string name="provider_unison">Unison</string>
+
+    <!-- AboutScreen -->
+    <string name="about_debug">Gỡ LỖI</string>
+    <string name="about_koiverse">Koiverse</string>
+    <string name="about_lead_developer">Nhà phát triển chính</string>
+    <string name="about_collaborators">Cộng tác viên</string>
+    <string name="about_contributors">Người đóng góp</string>
+
+    <!-- DiscordSettings -->
+    <string name="discord_listen_on_yt_music">Nghe trên YouTube Music</string>
+    <string name="discord_go_to_archivetune">Mở ArchiveTune</string>
+    <string name="edit_dialog_title">Chỉnh sửa %1$s</string>
+    <string name="bullet_item">• %1$s</string>
+    <string name="selection_queue_title">Lựa chọn</string>
+    <string name="unknown_error">Lỗi không xác định</string>
+    <string name="version_prefix">v%1$s</string>
+    <string name="together_default_port">42117</string>
+    <string name="tempo_pitch_display">x%1$.2f • x%2$.2f</string>
+    <string name="volume_percentage">%1$d%%</string>
+    <string name="tempo_multiplier">x%1$.2f</string>
+    <string name="pitch_multiplier">x%1$.2f</string>
+    <string name="semitone_value">%1$+d</string>
+    <string name="playback_error_decoder">%1$s (mã %2$d)</string>
+    <string name="playback_error_http">%1$s (HTTP %2$d)</string>
+    <string name="lastfm_api_key_not_configured">Khóa API Last.fm chưa được cấu hình</string>
+    <string name="seconds_format">%1$dgiây</string>
+    <string name="version_display">v%1$s (%2$d)</string>
+    <string name="no_playlists_yet">Chưa có danh sách phát nào</string>
+    <string name="add_to_n">Thêm vào %1$d</string>
+    <string name="add_to_playlist_short">Thêm</string>
+    <string name="no_stack_trace">Không có stack trace</string>
+    <string name="share_crash_log">Chia sẻ nhật ký sự cố</string>
+    <string name="time_am">SA</string>
+    <string name="time_pm">CH</string>
+    <string name="suggestions_available">Có gợi ý</string>
+    <string name="crash_report_header">Báo cáo sự cố ArchiveTune</string>
+    <string name="crash_report_time">Thời gian: %1$s</string>
+    <string name="crash_report_app">Ứng dụng: %1$s</string>
+    <string name="crash_report_package">Gói: %1$s</string>
+    <string name="crash_report_device_section">Thiết bị</string>
+    <string name="crash_report_stack_trace_section">Stack trace</string>
+    <string name="device_os_version">Phiên bản OS</string>
+    <string name="device_phone_name">Tên điện thoại</string>
+    <string name="device_model">Mẫu máy</string>
+    <string name="device_manufacturer">Nhà sản xuất</string>
+    <string name="device_brand">Thương hiệu</string>
+    <string name="device_device">Thiết bị</string>
+    <string name="device_product">Sản phẩm</string>
+    <string name="device_hardware">Phần cứng</string>
+    <string name="device_fingerprint">Fingerprint</string>
+    <string name="device_os_version_value">Android %1$s (SDK %2$d)</string>
+
+    <!-- AddToPlaylistDialogOnline -->
+    <string name="import_complete">Nhập hoàn tất</string>
+    <string name="total_processed">Đã xử lý: %1$d</string>
+    <string name="successfully_imported">Đã nhập thành công: %1$d</string>
+    <string name="failed_imports">Thất bại: %1$d</string>
+    <string name="failed_items_section">Mục thất bại:</string>
+
+    <!-- AddToPlaylistDialog -->
+    <string name="add_to_playlist">Thêm vào danh sách phát</string>
+    <string name="n_d_selected">Đã chọn %1$d</string>
+
+    <!-- NetworkStatusBanner -->
+    <string name="no_internet_connection">Không có kết nối internet</string>
+    <string name="back_online">Đã kết nối lại</string>
+
+    <!-- LyricsV2 -->
+    <string name="resume_lyrics">Tiếp tục</string>
+
+    <!-- SearchBar -->
+    <string name="search_cd">Tìm kiếm</string>
+
+    <!-- ThumbnailCornerRadiusSelector -->
+    <string name="dp_unit">dp</string>
+    <string name="min_radius">0</string>
+    <string name="max_radius">45</string>
+
+    <!-- StatsScreen -->
+    <string name="time_12am">12SA</string>
+    <string name="time_6am">6SA</string>
+    <string name="time_12pm">12CH</string>
+    <string name="time_6pm">6CH</string>
+
+    <!-- Start Mix -->
+    <string name="start_mix_cd">Bắt đầu Mix</string>
+
+    <!-- CachePlaylistScreen -->
+    <string name="cache_songs_title">Cache bài hát</string>
+
+    <!-- ShowMediaInfo -->
+    <string name="itag_label">Itag</string>
+    <string name="kbps_unit">%1$d Kbps</string>
+
+    <!-- App.kt -->
+    <string name="failed_to_parse_proxy">Không thể phân tích cài đặt proxy.</string>
+
+    <!-- Player.kt -->
+    <string name="by_prefix">của - %1$s</string>
+
+    <!-- Queue.kt -->
+    <string name="speaker_default">Loa</string>
+
+    <!-- LastFMSettings -->
+    <string name="login_enter_credentials">Vui lòng nhập tên người dùng và mật khẩu</string>
+    <string name="login_invalid_credentials">Tên người dùng hoặc mật khẩu không hợp lệ</string>
+    <string name="login_invalid_api_key">Khóa API không hợp lệ. Vui lòng liên hệ với nhà phát triển.</string>
+    <string name="login_auth_error">Lỗi xác thực. Vui lòng thử lại.</string>
+    <string name="login_api_key_suspended">Khóa API bị đình chỉ. Vui lòng liên hệ với nhà phát triển.</string>
+    <string name="login_network_error">Lỗi mạng. Kiểm tra kết nối của bạn.</string>
+    <string name="login_failed_generic">Đăng nhập thất bại. Vui lòng thử lại.</string>
+
+    <!-- AppearanceSettings -->
+    <string name="glow_animated">Phát sáng có hoạt ảnh</string>
+
+    <!-- AccountSettings -->
+    <string name="integration_subtitle">Discord, Last.fm, ListenBrainz</string>
+
+    <!-- PalettePickerScreen -->
+    <string name="default_theme_name">Giao diện ArchiveTune</string>
+
+    <!-- LocalMixQueue -->
+    <string name="mix_from_playlist">Trộn từ danh sách phát</string>
+
+    <!-- LyricsMenu -->
+    <string name="synced_badge">Đã đồng bộ</string>
+
+    <!-- ArtistSeparatorsDialog -->
+    <string name="separator_display">\"%1$s\"</string>
+
+    <!-- AboutScreen content descriptions -->
+    <string name="about_github">GitHub</string>
+    <string name="about_website">Trang web</string>
+    <string name="about_discord">Discord</string>
+
+    <!-- Internal/External -->
+    <string name="internal_service">Dịch vụ nội bộ</string>
+    <string name="external_service">Dịch vụ bên ngoài</string>
+
+    <!-- Backup -->
+    <string name="backup_data_safety">An toàn dữ liệu</string>
+    <string name="backup_data_safety_desc">Tạo bản sao lưu hoặc khôi phục dữ liệu ứng dụng đã chọn.</string>
+    <string name="backup_data_formats">Bản lưu .backup</string>
+    <string name="backup_create_backup_desc">Xuất thư viện, cài đặt và thông tin tài khoản.</string>
+    <string name="backup_restore_backup_desc">Khôi phục dữ liệu đã chọn từ bản sao lưu trước đó.</string>
+
+    <!-- Import -->
+    <string name="import_from_file">Nhập từ tệp</string>
+    <string name="import_from_file_desc">Mang danh sách phát từ tệp M3U hoặc CSV cục bộ.</string>
+    <string name="import_m3u_format">Danh sách phát âm thanh M3U</string>
+    <string name="import_csv_format">Tệp CSV danh sách phát</string>
+
+    <!-- Spotify -->
+    <string name="spotify_connect">Kết nối Spotify</string>
+    <string name="spotify_refresh">Làm mới thư viện Spotify</string>
+    <string name="spotify_available_count">%1$d danh sách phát có sẵn</string>
+    <string name="spotify_connected_as">Đã kết nối với tư cách %1$s</string>
+    <string name="spotify_not_connected">Spotify chưa được kết nối</string>
+    <string name="spotify_track_count">%1$d bài hát</string>
+    <string name="spotify_login_title">Đăng nhập Spotify</string>
+    <string name="spotify_loading_library">Đang tải thư viện Spotify</string>
+    <string name="spotify_no_sources">Không tìm thấy danh sách phát Spotify nào</string>
+    <string name="spotify_account">Tài khoản Spotify</string>
+    <string name="spotify_playlists">Danh sách phát Spotify</string>
+    <string name="spotify_waiting_for_login">Đang chờ đăng nhập Spotify</string>
+    <string name="spotify_show_playlist">Hiển thị danh sách phát</string>
+    <string name="spotify_show_playlist_desc">Hiển thị danh sách phát Spotify trong Thư viện.</string>
+    <string name="spotify_reload_playlist">Tải lại danh sách phát</string>
+    <string name="spotify_reload_playlist_desc">Làm mới danh sách phát Spotify từ tài khoản của bạn.</string>
+    <string name="spotify_no_tracks">Không tìm thấy bài hát Spotify nào.</string>
+
+    <!-- Restart -->
+    <string name="restart">Khởi động lại</string>
+
+    <!-- News -->
+    <string name="news">Tin Tức từ Nhà Phát Triển</string>
+    <string name="news_loading">Đang tải tin tức…</string>
+    <string name="news_empty_title">Chưa có gì ở đây</string>
+    <string name="news_empty_desc">Hiện không có thông báo nào. Quay lại sau nhé.</string>
+    <string name="news_error_title">Không thể tải tin tức</string>
+    <string name="news_error_desc">Kiểm tra kết nối internet của bạn và thử lại.</string>
+    <string name="news_retry">Thử lại</string>
+    <string name="news_search_placeholder">Tìm kiếm tin tức…</string>
+    <string name="news_search_results_title">Kết quả tìm kiếm</string>
+    <string name="news_no_results_title">Không có bài viết phù hợp</string>
+    <string name="news_no_results_desc">Thử một từ khóa khác.</string>
+    <string name="news_important_badge">Quan trọng</string>
+    <string name="news_tooltip_title">Thông Báo Mới</string>
+    <string name="news_tooltip_body">Bạn có thông báo chưa đọc từ nhà phát triển.</string>
+    <string name="news_author_on_date">%1$s · %2$s</string>
+    <plurals name="news_article_count">
+        <item quantity="one">%d bài viết</item>
+        <item quantity="other">%d bài viết</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -221,6 +221,7 @@
     <string name="starting_radio">Starting radio</string>
     <string name="now_playing">Now Playing</string>
     <string name="close">Close</string>
+    <string name="restart">Restart</string>
     <string name="minimum_volume">Minimum Volume</string>
     <string name="maximum_volume">Maximum Volume</string>
     <string name="hide_player_thumbnail">Hide Player Thumbnail</string>
@@ -585,4 +586,194 @@
     <string name="ai_api_test_failed">API test failed</string>
     <string name="ai_translation_menu">AI Translation</string>
     <string name="ai_translating_lyrics">Translating The Lyrics...</string>
+
+    <!-- DebugActivity -->
+    <string name="share_logs">Share Logs</string>
+    <string name="crash_report">Crash Report</string>
+    <string name="application_crashed">Application crashed</string>
+    <string name="device_info">Device info</string>
+    <string name="stack_trace">Stack trace</string>
+
+    <!-- PlayerComponents -->
+    <string name="copied_title">Copied Title</string>
+    <string name="copied_artist">Copied Artist</string>
+    <string name="blurred_background">Blurred background</string>
+    <string name="custom_background">Custom background</string>
+    <string name="codec_lossless">Lossless</string>
+    <string name="codec_aac">AAC</string>
+    <string name="codec_vorbis">Vorbis</string>
+    <string name="codec_opus">OPUS</string>
+
+    <!-- LyricsAnimationSettings -->
+    <string name="animation_tuning">Animation Tuning</string>
+    <string name="line_bounce_effect">Line Bounce Effect</string>
+    <string name="line_bounce_effect_desc">Enable bounce animation for line-synced (LRC) lyrics</string>
+    <string name="bounce_amplitude">Bounce Amplitude</string>
+    <string name="bounce_amplitude_desc">Adjust the bounce effect when a word is sung (%d%%)</string>
+    <string name="glow_intensity">Glow Intensity</string>
+    <string name="glow_intensity_desc">Adjust the glow brightness of the sung word (%d%%)</string>
+    <string name="fill_transition_smoothness">Fill Transition Smoothness</string>
+    <string name="fill_transition_smoothness_desc">Adjust the gradient edge width of the liquid fill effect (%d dp)</string>
+
+    <!-- UpdateScreen -->
+    <string name="update_dialog_intro">ArchiveTune provides two download channels for builds:</string>
+    <string name="stable_builds">• Stable builds</string>
+    <string name="stable_builds_desc_1">Distributed via official GitHub Releases.</string>
+    <string name="stable_builds_desc_2">These versions are tested and recommended for most users.</string>
+    <string name="nightly_builds">• Nightly builds</string>
+    <string name="nightly_builds_desc_1">Automatically generated development builds hosted via nightly.link.</string>
+    <string name="nightly_builds_desc_2">Nightly builds may include experimental features, unfinished changes, or temporary regressions.</string>
+    <string name="nightly_builds_desc_3">Nightly builds are provided for testing and early access only.\nStability, compatibility, and functionality are not guaranteed.</string>
+    <string name="nightly_builds_desc_4">By continuing, you acknowledge that nightly builds may be unstable and use them at your own risk.</string>
+
+    <!-- LyricsSettings provider names -->
+    <string name="paxsenix_apple_music">Paxsenix: Apple Music</string>
+    <string name="paxsenix_netease">Paxsenix: NetEase</string>
+    <string name="paxsenix_spotify">Paxsenix: Spotify</string>
+    <string name="paxsenix_musixmatch">Paxsenix: Musixmatch</string>
+    <string name="paxsenix_kugou">Paxsenix: KuGou</string>
+    <string name="provider_off">Off</string>
+    <string name="provider_lrclib">LrcLib</string>
+    <string name="provider_kugou">KuGou</string>
+    <string name="provider_better_lyrics">BetterLyrics</string>
+    <string name="provider_simpmusic">SimpMusic</string>
+    <string name="provider_unison">Unison</string>
+
+    <!-- AboutScreen -->
+    <string name="about_debug">DEBUG</string>
+    <string name="about_koiverse">Koiverse</string>
+    <string name="about_lead_developer">Lead Developer</string>
+    <string name="about_collaborators">Collaborators</string>
+    <string name="about_contributors">Contributors</string>
+
+    <!-- DiscordSettings -->
+    <string name="discord_listen_on_yt_music">Listen on YouTube Music</string>
+    <string name="discord_go_to_archivetune">Go to ArchiveTune</string>
+    <string name="edit_dialog_title">Edit %1$s</string>
+    <string name="bullet_item">• %1$s</string>
+    <string name="selection_queue_title">Selection</string>
+    <string name="unknown_error">Unknown error</string>
+    <string name="version_prefix">v%1$s</string>
+    <string name="together_default_port">42117</string>
+    <string name="tempo_pitch_display">x%1$.2f • x%2$.2f</string>
+    <string name="volume_percentage">%1$d%%</string>
+    <string name="tempo_multiplier">x%1$.2f</string>
+    <string name="pitch_multiplier">x%1$.2f</string>
+    <string name="semitone_value">%1$+d</string>
+    <string name="playback_error_decoder">%1$s (code %2$d)</string>
+    <string name="playback_error_http">%1$s (HTTP %2$d)</string>
+    <string name="lastfm_api_key_not_configured">Last.fm API key not configured</string>
+    <string name="seconds_format">%1$ds</string>
+    <string name="version_display">v%1$s (%2$d)</string>
+    <string name="no_playlists_yet">No playlists yet</string>
+    <string name="add_to_n">Add to %1$d</string>
+    <string name="add_to_playlist_short">Add</string>
+    <string name="no_stack_trace">No stack trace available</string>
+    <string name="share_crash_log">Share crash log</string>
+    <string name="time_am">AM</string>
+    <string name="time_pm">PM</string>
+    <string name="suggestions_available">Suggestions available</string>
+    <string name="crash_report_header">ArchiveTune crash report</string>
+    <string name="crash_report_time">Time: %1$s</string>
+    <string name="crash_report_app">App: %1$s</string>
+    <string name="crash_report_package">Package: %1$s</string>
+    <string name="crash_report_device_section">Device</string>
+    <string name="crash_report_stack_trace_section">Stack trace</string>
+    <string name="device_os_version">OS version</string>
+    <string name="device_phone_name">Phone name</string>
+    <string name="device_model">Model</string>
+    <string name="device_manufacturer">Manufacturer</string>
+    <string name="device_brand">Brand</string>
+    <string name="device_device">Device</string>
+    <string name="device_product">Product</string>
+    <string name="device_hardware">Hardware</string>
+    <string name="device_fingerprint">Fingerprint</string>
+    <string name="device_os_version_value">Android %1$s (SDK %2$d)</string>
+
+    <!-- AddToPlaylistDialogOnline -->
+    <string name="import_complete">Import Complete</string>
+    <string name="total_processed">Total Processed: %1$d</string>
+    <string name="successfully_imported">Successfully Imported: %1$d</string>
+    <string name="failed_imports">Failed: %1$d</string>
+    <string name="failed_items_section">Failed Items:</string>
+
+    <!-- AddToPlaylistDialog -->
+    <string name="add_to_playlist">Add to playlist</string>
+    <string name="n_d_selected">%1$d selected</string>
+
+    <!-- NetworkStatusBanner -->
+    <string name="no_internet_connection">No internet connection</string>
+    <string name="back_online">Back online</string>
+
+    <!-- LyricsV2 -->
+    <string name="resume_lyrics">Resume</string>
+
+    <!-- SearchBar -->
+    <string name="search_cd">Search</string>
+
+    <!-- ThumbnailCornerRadiusSelector -->
+    <string name="dp_unit">dp</string>
+    <string name="min_radius">0</string>
+    <string name="max_radius">45</string>
+
+    <!-- NewReleaseScreen -->
+    <string name="new_releases_unavailable">New releases are temporarily unavailable</string>
+    <string name="new_releases_unavailable_desc">ArchiveTune could not load this YouTube Music section. Try again later.</string>
+
+    <!-- StatsScreen -->
+    <string name="time_12am">12AM</string>
+    <string name="time_6am">6AM</string>
+    <string name="time_12pm">12PM</string>
+    <string name="time_6pm">6PM</string>
+
+    <!-- Start Mix content description -->
+    <string name="start_mix_cd">Start Mix</string>
+
+    <!-- CachePlaylistScreen -->
+    <string name="cache_songs_title">Cache Songs</string>
+
+    <!-- ShowMediaInfo -->
+    <string name="itag_label">Itag</string>
+    <string name="kbps_unit">%1$d Kbps</string>
+
+    <!-- App.kt -->
+    <string name="failed_to_parse_proxy">Failed to parse proxy settings.</string>
+
+    <!-- Player.kt -->
+    <string name="by_prefix">by - %1$s</string>
+
+    <!-- Queue.kt -->
+    <string name="speaker_default">Speaker</string>
+
+    <!-- LastFMSettings -->
+    <string name="login_enter_credentials">Please enter username and password</string>
+    <string name="login_invalid_credentials">Invalid username or password</string>
+    <string name="login_invalid_api_key">Invalid API key. Please contact the developer.</string>
+    <string name="login_auth_error">Authentication error. Please try again.</string>
+    <string name="login_api_key_suspended">API key suspended. Please contact the developer.</string>
+    <string name="login_network_error">Network error. Check your connection.</string>
+    <string name="login_failed_generic">Login failed. Please try again.</string>
+
+    <!-- AppearanceSettings -->
+    <string name="glow_animated">Glow Animated</string>
+
+    <!-- AccountSettings -->
+    <string name="integration_subtitle">Discord, Last.fm, ListenBrainz</string>
+
+    <!-- PalettePickerScreen -->
+    <string name="default_theme_name">ArchiveTune Theme</string>
+
+    <!-- LocalMixQueue -->
+    <string name="mix_from_playlist">Mix from Playlist</string>
+
+    <!-- LyricsMenu -->
+    <string name="synced_badge">Synced</string>
+
+    <!-- ArtistSeparatorsDialog -->
+    <string name="separator_display">\"%1$s\"</string>
+
+    <!-- AboutScreen content descriptions -->
+    <string name="about_github">GitHub</string>
+    <string name="about_website">Website</string>
+    <string name="about_discord">Discord</string>
 </resources>


### PR DESCRIPTION
- Extract all hardcoded Kotlin strings into stringResource references across 37 UI files
- Add Vietnamese (values-vi) translations — ~340 new strings, now 695 total
- Add Japanese (values-ja) translations — ~250 new strings, now 695 total
- Both locales now fully match the English source (695 strings each)