### PR TITLE
feat: add snackbar notifications for dialog operations (backup, update)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -51,6 +52,8 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -156,6 +159,13 @@ fun BackupAndRestore(
     val (showSpotifyPlaylists, onShowSpotifyPlaylistsChange) = rememberPreference(ShowSpotifyPlaylistsKey, false)
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.backupEvent.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
 
     val backupLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
@@ -210,79 +220,89 @@ fun BackupAndRestore(
         }
     }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
-        PreferenceGroup(title = stringResource(R.string.internal_service)) {
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.action_backup)) },
-                    description = stringResource(R.string.backup_create_backup_desc),
-                    icon = { Icon(painterResource(R.drawable.backup), null) },
-                    onClick = { showBackupOptionsDialog = true },
-                )
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.internal_service)) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.action_backup)) },
+                        description = stringResource(R.string.backup_create_backup_desc),
+                        icon = { Icon(painterResource(R.drawable.backup), null) },
+                        onClick = { showBackupOptionsDialog = true },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.action_restore)) },
+                        description = stringResource(R.string.restore_select_backup),
+                        icon = { Icon(painterResource(R.drawable.restore), null) },
+                        onClick = { restoreLauncher.launch(arrayOf("application/octet-stream", "application/zip")) },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.import_online)) },
+                        description = stringResource(R.string.import_m3u_format),
+                        icon = { Icon(painterResource(R.drawable.playlist_import), null) },
+                        onClick = { importM3uLauncherOnline.launch(arrayOf("audio/*")) },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.import_csv)) },
+                        description = stringResource(R.string.import_csv_format),
+                        icon = { Icon(painterResource(R.drawable.playlist_add), null) },
+                        onClick = { importPlaylistFromCsv.launch(CSV_MIME_TYPES) },
+                    )
+                }
             }
 
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.action_restore)) },
-                    description = stringResource(R.string.restore_select_backup),
-                    icon = { Icon(painterResource(R.drawable.restore), null) },
-                    onClick = { restoreLauncher.launch(arrayOf("application/octet-stream", "application/zip")) },
-                )
-            }
-
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.import_online)) },
-                    description = stringResource(R.string.import_m3u_format),
-                    icon = { Icon(painterResource(R.drawable.playlist_import), null) },
-                    onClick = { importM3uLauncherOnline.launch(arrayOf("audio/*")) },
-                )
-            }
-
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.import_csv)) },
-                    description = stringResource(R.string.import_csv_format),
-                    icon = { Icon(painterResource(R.drawable.playlist_add), null) },
-                    onClick = { importPlaylistFromCsv.launch(CSV_MIME_TYPES) },
+            PreferenceGroup(title = stringResource(R.string.external_service)) {
+                spotifyAccountPreferences(
+                    state = spotifyState,
+                    showPlaylists = showSpotifyPlaylists,
+                    onConnectClick = { showSpotifyLogin = true },
+                    onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
+                    onReloadClick = spotifyAccountViewModel::reloadPlaylists,
+                    onLogoutClick = {
+                        spotifyAccountViewModel.logout()
+                    },
                 )
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.external_service)) {
-            spotifyAccountPreferences(
-                state = spotifyState,
-                showPlaylists = showSpotifyPlaylists,
-                onConnectClick = { showSpotifyLogin = true },
-                onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
-                onReloadClick = spotifyAccountViewModel::reloadPlaylists,
-                onLogoutClick = {
-                    spotifyAccountViewModel.logout()
-                },
-            )
-        }
+        TopAppBar(
+            title = { Text(stringResource(R.string.backup_restore)) },
+            navigationIcon = {
+                IconButton(
+                    onClick = navController::navigateUp,
+                    onLongClick = navController::backToMain,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.arrow_back),
+                        contentDescription = null,
+                    )
+                }
+            },
+            scrollBehavior = scrollBehavior,
+        )
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom))
+                .padding(16.dp),
+        )
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.backup_restore)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-        scrollBehavior = scrollBehavior,
-    )
 
     if (showBackupOptionsDialog) {
         BackupOptionsDialog(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SegmentedListItem
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -189,6 +191,7 @@ fun UpdateScreen(
     var updateDownloadJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     var showUpdateDownloadDialog by remember { mutableStateOf(false) }
     val useInAppUpdateInstaller = BuildConfig.DISTRIBUTION == "gms"
+    val snackbarHostState = remember { SnackbarHostState() }
 
     val openUpdateUrl: (String) -> Unit = { url ->
         try {
@@ -212,6 +215,9 @@ fun UpdateScreen(
                             updateDownloadProgress = progress.fraction
                         }.onSuccess {
                             showUpdateDownloadDialog = false
+                            snackbarHostState.showSnackbar(
+                                context.getString(R.string.download_complete),
+                            )
                         }.onFailure { error ->
                             showUpdateDownloadDialog = false
                             updateSheetError = error.message ?: context.getString(R.string.error_unknown)
@@ -573,6 +579,7 @@ fun UpdateScreen(
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.surface,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
@@ -731,11 +738,24 @@ fun UpdateScreen(
         val determinateIndicatorModifier = remember { Modifier.fillMaxSize() }
         val indeterminateIndicatorModifier = remember { Modifier.size(72.dp) }
 
+        val downloadTitle = buildString {
+            when (updateChannel) {
+                UpdateChannel.DAILY_NIGHTLY -> append("${context.getString(R.string.app_name)} Nightly")
+                else -> append(context.getString(R.string.app_name))
+            }
+            append(' ')
+            if (updateChannel == UpdateChannel.NIGHTLY) {
+                append(latestCommit?.sha?.take(7) ?: updateSheetVersion ?: "?")
+            } else {
+                append(updateSheetVersion ?: "?")
+            }
+        }
+
         AlertDialog(
             onDismissRequest = {},
             title = {
                 Text(
-                    text = stringResource(R.string.downloading),
+                    text = downloadTitle,
                     style = MaterialTheme.typography.headlineSmall,
                     textAlign = TextAlign.Center,
                     modifier = centeredDialogContentModifier,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
@@ -22,8 +22,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -167,6 +170,9 @@ class BackupRestoreViewModel
         private val _backupRestoreProgress = MutableStateFlow<BackupRestoreProgressUi?>(null)
         val backupRestoreProgress: StateFlow<BackupRestoreProgressUi?> = _backupRestoreProgress.asStateFlow()
 
+        private val _backupEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
+        val backupEvent: SharedFlow<String> = _backupEvent.asSharedFlow()
+
         private fun emitProgress(
             title: String,
             step: String,
@@ -280,13 +286,16 @@ class BackupRestoreViewModel
                         }
                     } ?: throw IllegalStateException("Failed to open output stream")
 
+                    val msg = context.getString(R.string.backup_create_success)
+                    _backupEvent.tryEmit(msg)
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, R.string.backup_create_success, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
                     }
                 } catch (exception: Exception) {
                     reportException(exception)
+                    val msg = exception.message ?: context.getString(R.string.backup_create_failed)
+                    _backupEvent.tryEmit(msg)
                     withContext(Dispatchers.Main) {
-                        val msg = exception.message ?: context.getString(R.string.backup_create_failed)
                         Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
                     }
                 } finally {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -817,6 +817,7 @@
     <string name="update_notification_title">Update Available</string>
     <string name="update_notification_text">ArchiveTune %s is now available</string>
     <string name="download">Download</string>
+    <string name="download_complete">Download complete</string>
     <string name="permissions_title">Allow ArchiveTune to work best</string>
     <string name="permissions_subtitle">We use a few permissions to play and manage your music reliably. You can change these anytime in system settings.</string>
     <string name="permission_storage_title">Storage access</string>


### PR DESCRIPTION
Adds Snackbar notifications for:

- **Backup**: successful/failed backup now shows a Snackbar in the Backup & Restore settings screen (via new backupEvent SharedFlow)
- **Update download**: download completion shows a Snackbar; dialog title shows filename (ArchiveTune {version} or ArchiveTune {commit} for Nightly)