### PR TITLE
feat: open search overlay when tapping Search tab while already on search screen

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1155,9 +1155,13 @@ class MainActivity : ComponentActivity() {
 
                     val handlePrimaryNavigationClick: (Screens, Boolean) -> Unit = { screen, isSelected ->
                         if (isSelected) {
-                            navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
-                            coroutineScope.launch {
-                                searchBarScrollBehavior.state.resetHeightOffset()
+                            if (screen == Screens.Search) {
+                                openSearch()
+                            } else {
+                                navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
+                                coroutineScope.launch {
+                                    searchBarScrollBehavior.state.resetHeightOffset()
+                                }
                             }
                         } else {
                             navController.navigate(screen.route) {


### PR DESCRIPTION
## Summary
When the user is already on the search discovery screen, tapping the Search tab in the floating navigation toolbar now opens the song search overlay instead of scrolling to top.

## Changes
- Modified `handlePrimaryNavigationClick` in `MainActivity.kt` to check if the tapped screen is `Screens.Search` when already selected
- If already on Search screen → opens the search overlay (`openSearch()`)
- Other tabs (Home, Library) retain the existing scroll-to-top behavior when already selected

## Behavior
| Action | Before | After |
|---|---|---|
| Tap Search tab (from another tab) | Navigate to search discovery | Navigate to search discovery (unchanged) |
| Tap Search tab (already on search) | Scroll to top | Open search overlay |
| Double-tap Search tab (any screen) | Open search with ONLINE source | Open search with ONLINE source (unchanged) |
| Tap Home/Library when selected | Scroll to top | Scroll to top (unchanged) |